### PR TITLE
fix(ci): add emulator to PATH and increase CUA smoke timeout to 60min

### DIFF
--- a/.github/workflows/cua-smoke.yml
+++ b/.github/workflows/cua-smoke.yml
@@ -13,13 +13,14 @@ on:
 jobs:
   cua-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
           node-version: 20
+          cache: npm
 
       - uses: actions/setup-java@v5
         with:
@@ -28,6 +29,20 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4
+
+      - name: Add emulator to PATH
+        run: echo "$ANDROID_HOME/emulator" >> $GITHUB_PATH
+
+      - name: Cache Gradle
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            android/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Install Android system image & create AVD
         run: |


### PR DESCRIPTION
## Problem

CUA smoke test has been failing/cancelling on every push with:

```
emulator: command not found
```

`android-actions/setup-android@v4` sets `ANDROID_HOME` but does **not** add `$ANDROID_HOME/emulator` to `$PATH`. As a result `adb wait-for-device` hangs indefinitely (emulator never started) until the 30-min job timeout kicks in and cancels the run.

## Changes

- **Add emulator to PATH** step after `setup-android` — `echo "$ANDROID_HOME/emulator" >> $GITHUB_PATH`
- **Increase timeout** from 30 → 60 min (build + emulator boot + test needs ~45 min without cache)
- **Add npm and Gradle caches** (identical to `build.yml`) to speed up successive runs

## Verification

Watch the next CI run — "Start emulator" step should complete and the rest of the job should proceed.