### PR TITLE
chore: repoint OpenCode links to agentlabs.cc/opencode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ OpenCode Mobile is a thin client. It speaks the opencode HTTP + SSE API: listing
 
 ## Supporters and Sponsors
 
-OpenCode Mobile is built and maintained by [VIBE TECHNOLOGIES, LLC](https://www.vibebrowser.app/opencode). GitHub Sponsors help cover Sentry, EAS Build, and CI costs (~$60/month). The opencode Cloud hosted backend (planned, $10/mo) is the long-term revenue model.
+OpenCode Mobile is built and maintained by [VIBE TECHNOLOGIES, LLC](https://agentlabs.cc/opencode). GitHub Sponsors help cover Sentry, EAS Build, and CI costs (~$60/month). The opencode Cloud hosted backend (planned, $10/mo) is the long-term revenue model.
 
 If OpenCode Mobile saves you time, consider sponsoring:
 
@@ -135,7 +135,7 @@ If OpenCode Mobile saves you time, consider sponsoring:
 |---|---|---|
 | Supporter | $5/mo | Your name in `SUPPORTERS.md` |
 | Backer | $15/mo | Name + early access to opencode Cloud beta |
-| Business | $50/mo | Logo on [agentlabs.cc/opencode](https://www.vibebrowser.app/opencode) + quarterly support call |
+| Business | $50/mo | Logo on [agentlabs.cc/opencode](https://agentlabs.cc/opencode) + quarterly support call |
 
 Questions or private support: [support@vibebrowser.app](mailto:support@vibebrowser.app)
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -202,7 +202,7 @@ export default function SettingsScreen() {
           label="Privacy Policy"
           description="What data we collect and how"
           isDark={isDark}
-          onPress={() => Linking.openURL("https://www.vibebrowser.app/opencode-mobile/privacy")}
+          onPress={() => Linking.openURL("https://agentlabs.cc/opencode/privacy")}
           right={<Ionicons name="open-outline" size={20} color={isDark ? "#666666" : "#999999"} />}
         />
       </SettingSection>

--- a/distribution/app-store-listing.md
+++ b/distribution/app-store-listing.md
@@ -101,7 +101,7 @@ Alternative / supplemental terms to rotate in A/B: `code review`, `AI assistant`
 
 | Field | Value |
 |---|---|
-| Support URL | https://www.vibebrowser.app/opencode |
+| Support URL | https://agentlabs.cc/opencode |
 | Marketing URL | https://github.com/dzianisv/opencode-mobile |
 | Privacy Policy URL | https://opencode.vibebrowser.app/privacy |
 

--- a/distribution/fdroid-submission/metadata.yml
+++ b/distribution/fdroid-submission/metadata.yml
@@ -21,7 +21,7 @@ License: MIT
 AuthorName: VIBE TECHNOLOGIES, LLC
 AuthorEmail: support@vibebrowser.app
 
-WebSite: https://www.vibebrowser.app/opencode
+WebSite: https://agentlabs.cc/opencode
 SourceCode: https://github.com/dzianisv/opencode-mobile
 IssueTracker: https://github.com/dzianisv/opencode-mobile/issues
 Changelog: https://github.com/dzianisv/opencode-mobile/releases

--- a/distribution/ios-enrollment-runbook.md
+++ b/distribution/ios-enrollment-runbook.md
@@ -18,7 +18,7 @@ Reference: https://developer.apple.com/programs/enroll/
 | Primary Contact / Authorized Agent | Dzianis Vashchuk | Governor of LLC |
 | Primary Contact Phone | (use a number reachable for Apple's verification call) | |
 | Primary Contact Email | support@vibebrowser.app | |
-| Website | https://www.vibebrowser.app/opencode | |
+| Website | https://agentlabs.cc/opencode | |
 
 ---
 
@@ -62,7 +62,7 @@ Fill as follows:
 | ZIP | `98108` |
 | Country | `United States` |
 | Phone | (Dzianis's direct mobile — Apple calls this) |
-| Website | `https://www.vibebrowser.app/opencode` |
+| Website | `https://agentlabs.cc/opencode` |
 
 ### Step 4 — Verify Your Authority
 
@@ -113,7 +113,7 @@ While waiting for Apple's verification call and approval:
 - [ ] Create app icon 1024×1024 PNG
 - [ ] Capture iPhone screenshots (use iOS Simulator in Xcode on any Mac)
 - [ ] Capture iPad screenshots
-- [ ] Write/publish privacy policy at https://www.vibebrowser.app/opencode-mobile/privacy
+- [ ] Write/publish privacy policy at https://agentlabs.cc/opencode/privacy
 - [ ] Set up EAS account at https://expo.dev/ (free tier, log in with Expo account)
 - [ ] Add iOS config patches to `app.json` (done in this PR)
 - [ ] Run `npx expo prebuild --platform ios` on a Mac to validate the Xcode project

--- a/distribution/izzyondroid-submission/INCLUSION-REQUEST.md
+++ b/distribution/izzyondroid-submission/INCLUSION-REQUEST.md
@@ -106,5 +106,5 @@ We will notify the IzzyOnDroid team via this issue when that happens.
 
 Developer: VIBE TECHNOLOGIES, LLC
 Email: support@vibebrowser.app
-Website: https://www.vibebrowser.app/opencode
+Website: https://agentlabs.cc/opencode
 Privacy policy: https://opencode.vibebrowser.app/privacy

--- a/distribution/play-listing.md
+++ b/distribution/play-listing.md
@@ -114,7 +114,7 @@ Issues: github.com/dzianisv/opencode-mobile/issues
 | Tags | developer, ai, coding, open-source, productivity | Submit all five in Play Console. |
 | Email | support@vibebrowser.app | Already verified during signup. |
 | Phone | +1 360-504-8967 | Optional public; matches developer profile. |
-| Website | https://www.vibebrowser.app/opencode | Already verified. |
+| Website | https://agentlabs.cc/opencode | Already verified. |
 
 ---
 

--- a/distribution/privacy-policy.md
+++ b/distribution/privacy-policy.md
@@ -106,7 +106,7 @@ All diagnostic data is transmitted over HTTPS (TLS 1.2+) to Sentry. We do not tr
 ## 10. Changes to This Policy
 
 If we make material changes to this policy, we will update the effective date and, where feasible, notify users via an in-app notice. The latest version is always available at:
-https://www.vibebrowser.app/opencode-mobile/privacy
+https://agentlabs.cc/opencode/privacy
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -152,7 +152,7 @@ When the opencode AI agent requests a file-access permission, the notification b
 **Files:** `app.json:29`, `app.json:38-39`
 **Description:** Both platforms allow HTTP connections, which is required for local/LAN servers. This is intentional and correct for the use case. However, neither the Play Store listing, App Store listing, nor a privacy policy document currently explains that HTTP connections may be made to user-provided servers. Google Play's Data Safety section and Apple's App Privacy report will flag arbitrary network access if not documented.
 **Remediation:**
-1. Update the privacy policy at `vibebrowser.app/opencode-mobile/privacy` to explain that the app connects to user-configured server addresses that may use HTTP.
+1. Update the privacy policy at `agentlabs.cc/opencode/privacy` to explain that the app connects to user-configured server addresses that may use HTTP.
 2. In Play Store Data Safety: disclose "Other app performance data" collected (crash reports via Sentry — opt-in).
 **Status:** Open
 

--- a/src/components/TelemetryConsentModal.tsx
+++ b/src/components/TelemetryConsentModal.tsx
@@ -46,7 +46,7 @@ export function TelemetryConsentModal({ visible, onAllow, onDecline }: Props) {
 
           {/* Privacy policy link */}
           <TouchableOpacity
-            onPress={() => Linking.openURL("https://www.vibebrowser.app/opencode-mobile/privacy")}
+            onPress={() => Linking.openURL("https://agentlabs.cc/opencode/privacy")}
           >
             <Text style={styles.privacyLink}>Read our full privacy policy</Text>
           </TouchableOpacity>


### PR DESCRIPTION
agentlabs.cc/opencode and /opencode/privacy are live (200, verified). This repoints all references from the interim `www.vibebrowser.app/opencode` to the canonical `agentlabs.cc/opencode` hub.

**Changed:**
- README (maintainer link, sponsor tier)
- Distribution listings: Play, App Store, F-Droid, IzzyOnDroid, iOS runbook
- docs/security.md privacy-policy reference
- distribution/privacy-policy.md
- **In-app links** (runtime-facing): `settings.tsx` + `TelemetryConsentModal.tsx` privacy → `agentlabs.cc/opencode/privacy`

Left untouched: Search Console ownership refs to `www.vibebrowser.app/` (that verification is domain-level, not the opencode page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)