### PR TITLE
ux(quick-connect): hint custom server username path (#23)

### DIFF
--- a/app/connection/add.tsx
+++ b/app/connection/add.tsx
@@ -209,6 +209,13 @@ export default function AddConnectionScreen() {
           onChangeText={setPassword}
           secureTextEntry
         />
+        <Text style={[styles.usernameHint, isDark && styles.hintDark]}>
+          Username defaults to <Text style={styles.code}>opencode</Text>. Custom username? Use{" "}
+          <Text style={styles.usernameHintLink} onPress={() => setMode("advanced")}>
+            Advanced options
+          </Text>
+          .
+        </Text>
 
         {/* Connect button */}
         <TouchableOpacity
@@ -523,6 +530,17 @@ const styles = StyleSheet.create({
     backgroundColor: "#e5e5e5",
     paddingHorizontal: 4,
     borderRadius: 4,
+  },
+  usernameHint: {
+    fontSize: 12,
+    color: "#666666",
+    marginTop: 6,
+    marginBottom: 4,
+    lineHeight: 18,
+  },
+  usernameHintLink: {
+    color: "#6366f1",
+    fontWeight: "600",
   },
   advancedLink: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- Adds a one-line hint under the Quick Connect password field: states username defaults to \`opencode\` and links to Advanced options for servers with a custom \`OPENCODE_SERVER_USERNAME\`.
- Tap on \"Advanced options\" inside the hint switches the screen to advanced mode (same handler as the existing link).

## Why
Per #23 — the Quick Connect auth fix (defaulting username to \`opencode\`) covers most users, but custom-username servers were silently unreachable from the simple flow. A small hint surfaces the escape hatch without bloating Quick Connect.

## Changes
- \`app/connection/add.tsx\`: hint <Text> under the password input + new \`usernameHint\`/\`usernameHintLink\` styles.

## Verification
- \`npx tsc --noEmit\` — clean.
- Manual UI check pending on next CUA / device pass.

Closes #23