### PR TITLE
fix(ci): add emulator to PATH and increase CUA smoke timeout to 60min

### DIFF
--- a/.github/workflows/cua-smoke.yml
+++ b/.github/workflows/cua-smoke.yml
@@ -68,6 +68,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Purge stale generated sources
+        # The Gradle cache (restore-keys prefix fallback) can restore a
+        # generated autolinking tree from a previous package id. Gradle then
+        # reuses ReactNativeApplicationEntryPoint.java referencing the OLD
+        # package (ai.opencode.mobile.BuildConfig) and compileReleaseJavaWithJavac
+        # fails. Delete generated sources so prebuild + Gradle regenerate them
+        # for the current package (cc.agentlabs.opencode).
+        run: rm -rf android/app/build/generated android/build/generated android/app/build/intermediates
+
       - name: Install dependencies & build APK
         env:
           SENTRY_DISABLE_AUTO_UPLOAD: "true"

--- a/.github/workflows/cua-smoke.yml
+++ b/.github/workflows/cua-smoke.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   cua-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
       AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
@@ -47,6 +47,9 @@ jobs:
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4
+
+      - name: Add emulator to PATH
+        run: echo "$ANDROID_HOME/emulator" >> $GITHUB_PATH
 
       - name: Enable KVM
         run: |


### PR DESCRIPTION
## Summary
- Add Android emulator to PATH in CI
- Increase CUA smoke timeout to 60 minutes
- Upgrade upload/download-artifact to Node.js 24-compatible versions

## Test Plan
- [ ] CUA smoke CI job completes without emulator-not-found errors