### PR TITLE
test(cua): make sessions regression non-mutating

### DIFF
--- a/.github/workflows/cua-smoke.yml
+++ b/.github/workflows/cua-smoke.yml
@@ -18,7 +18,13 @@ jobs:
     env:
       AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
       AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+      # CUA driver uses chat-completions; 2024-08-01-preview is sufficient.
       AZURE_OPENAI_API_VERSION: "2024-08-01-preview"
+      # opencode's @ai-sdk/azure provider hits the new /openai/v1/responses
+      # endpoint, which requires 2025-03-01-preview or newer. Without this,
+      # probe returns "API version not supported" -> MODEL_CAPABLE=false ->
+      # send_message/multi_turn scenarios get skipped (#22).
+      OPENCODE_AZURE_API_VERSION: "2025-04-01-preview"
       # Android emulator reaches the runner host loopback via 10.0.2.2.
       # A real `opencode serve` runs on the host (see steps below), making this a true E2E.
       OPENCODE_URL: "http://10.0.2.2:4096"
@@ -92,7 +98,7 @@ jobs:
                 "options": {
                   "resourceName": "${RESOURCE_NAME}",
                   "apiKey": "{env:AZURE_OPENAI_API_KEY}",
-                  "apiVersion": "${AZURE_OPENAI_API_VERSION}"
+                  "apiVersion": "${OPENCODE_AZURE_API_VERSION}"
                 },
                 "models": {
                   "${AZURE_OPENAI_MODEL}": { "name": "Azure ${AZURE_OPENAI_MODEL}" }

--- a/.github/workflows/cua-smoke.yml
+++ b/.github/workflows/cua-smoke.yml
@@ -113,18 +113,40 @@ jobs:
 
       - name: Start opencode server on runner host
         run: |
+          set -x
           # Bind all interfaces so the emulator can reach it via 10.0.2.2.
           nohup opencode serve --hostname 0.0.0.0 --port 4096 > /tmp/opencode-server.log 2>&1 &
+          SRV_PID=$!
+          echo "opencode pid=$SRV_PID"
           echo "Waiting for opencode server /global/health ..."
+          HEALTHY=0
           for i in $(seq 1 60); do
-            if curl -sf http://127.0.0.1:4096/global/health > /dev/null; then
-              echo "opencode server healthy after ${i}s"; break
+            if curl -sf --connect-timeout 2 -m 5 http://127.0.0.1:4096/global/health > /dev/null; then
+              echo "opencode server healthy after ${i}s"
+              HEALTHY=1
+              break
+            fi
+            # Periodic state dump every 10s while waiting
+            if [ $((i % 10)) -eq 0 ]; then
+              echo "--- @${i}s: server log so far ---"
+              tail -20 /tmp/opencode-server.log || true
+              echo "--- listening ports ---"
+              ss -tlnp 2>/dev/null | grep -E ':4096|opencode' || echo "no listener on 4096"
+              echo "--- pid alive? ---"
+              kill -0 $SRV_PID 2>/dev/null && echo "pid $SRV_PID alive" || echo "pid $SRV_PID DEAD"
             fi
             sleep 1
           done
-          curl -sf http://127.0.0.1:4096/global/health || {
-            echo "::error::opencode server failed to become healthy"; cat /tmp/opencode-server.log; exit 1;
-          }
+          if [ "$HEALTHY" != "1" ]; then
+            echo "::error::opencode server failed to become healthy in 60s"
+            echo "--- final server log ---"
+            cat /tmp/opencode-server.log || true
+            echo "--- ss listing ---"
+            ss -tlnp 2>/dev/null || true
+            echo "--- ps tree ---"
+            ps -ef | grep -E 'opencode|node|npm' | head -20 || true
+            exit 1
+          fi
 
       - name: Probe opencode model capability (can it reply?)
         id: probe

--- a/.github/workflows/cua-smoke.yml
+++ b/.github/workflows/cua-smoke.yml
@@ -186,9 +186,9 @@ jobs:
           # Choose the scenario set HERE (bash) and export it, so the emulator step's
           # script (run by dash, which mangles multi-line if/fi blocks) stays single-line.
           if [ "$CAPABLE" = "true" ]; then
-            SCENARIOS="connect_and_verify_sessions,send_message,verify_session_list"
+            SCENARIOS="connect_and_verify_existing_sessions,send_message,verify_session_list"
           else
-            SCENARIOS="connect_and_verify_sessions,verify_session_list"
+            SCENARIOS="connect_and_verify_existing_sessions,verify_session_list"
             echo "WARN: opencode not model-capable in CI; excluding send_message/multi_turn (environmental, not an app bug)."
           fi
           echo "SCENARIOS=$SCENARIOS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cua-smoke.yml
+++ b/.github/workflows/cua-smoke.yml
@@ -21,10 +21,12 @@ jobs:
       # CUA driver uses chat-completions; 2024-08-01-preview is sufficient.
       AZURE_OPENAI_API_VERSION: "2024-08-01-preview"
       # opencode's @ai-sdk/azure provider hits the new /openai/v1/responses
-      # endpoint, which requires 2025-03-01-preview or newer. Without this,
-      # probe returns "API version not supported" -> MODEL_CAPABLE=false ->
-      # send_message/multi_turn scenarios get skipped (#22).
-      OPENCODE_AZURE_API_VERSION: "2025-04-01-preview"
+      # endpoint. That endpoint accepts ONLY api-version=preview or v1 — every
+      # date-based value (2024-*-preview, 2025-*-preview, 2025-04-01-preview)
+      # returns 400 "API version not supported" and forces MODEL_CAPABLE=false,
+      # which makes send_message/multi_turn scenarios get skipped (#22).
+      # `preview` is also the @ai-sdk/azure 3.x default.
+      OPENCODE_AZURE_API_VERSION: "preview"
       # Android emulator reaches the runner host loopback via 10.0.2.2.
       # A real `opencode serve` runs on the host (see steps below), making this a true E2E.
       OPENCODE_URL: "http://10.0.2.2:4096"

--- a/scripts/android-cua-smoke.py
+++ b/scripts/android-cua-smoke.py
@@ -565,16 +565,21 @@ SMOKE_SCENARIOS = [
         "goal": (
             "You see the OpenCode mobile app. Tap the '+' button (top-right) to create a new session. "
             "Tap the text input at the bottom. Type 'ping'. Press back to dismiss keyboard. "
-            "Use the send action. Wait 5 seconds. "
-            "Report success if you see both a 'You' bubble and an 'Assistant' bubble."
+            "Use the send action. Wait 5 seconds, then take another screenshot. "
+            "If you don't yet see an assistant reply, wait another 10 seconds and re-check (assistant replies can take 15+ seconds). "
+            "If still no assistant bubble, wait another 15 seconds and re-check one more time. "
+            "Report success if you see both a 'You' bubble and an 'Assistant' bubble. "
+            "Report failure only after at least 30 seconds of total waiting with no assistant bubble."
         ),
     },
     {
         "name": "multi_turn",
         "goal": (
             "You see the OpenCode mobile app. Tap '+' (top-right) to create a new session. "
-            "Tap the text input. Type 'what is 2+2'. Press back. Use send action. Wait 5 seconds. "
-            "Then tap the text input again, type 'and 3+3?'. Press back. Use send action. Wait 5 seconds. "
+            "Tap the text input. Type 'what is 2+2'. Press back. Use send action. "
+            "Wait up to 30 seconds for an assistant reply (re-check every 10 seconds). "
+            "Then tap the text input again, type 'and 3+3?'. Press back. Use send action. "
+            "Wait up to 30 seconds for the second assistant reply (re-check every 10 seconds). "
             "Report success if you see two assistant reply bubbles."
         ),
     },

--- a/scripts/android-cua-smoke.py
+++ b/scripts/android-cua-smoke.py
@@ -357,14 +357,16 @@ def execute_action(action: dict) -> str:
         return f"swiped ({x1},{y1})->({x2},{y2})"
 
     elif act == "send":
-        # Auto-locate send button: rightmost clickable ViewGroup in the bottom input bar
+        # Auto-locate send button: rightmost clickable ViewGroup in the bottom input bar.
+        # Threshold is screen-relative (bottom 25%) so it works on any emulator
+        # resolution — API 30 default profile is 1080x1920, not the 2400-tall pixel
+        # we previously hardcoded against.
+        screen_w, screen_h = get_screen_size()
+        bottom_threshold = int(screen_h * 0.75)
         xml = ui_dump()
-        # Find the EditText (message input) and the clickable element immediately after it
-        # The send button is the last clickable ViewGroup in the input row
         matches = re.findall(r'clickable="true"[^>]*bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"', xml)
         if matches:
-            # Find the rightmost clickable element near the bottom (y > 2200)
-            bottom_buttons = [(int(x1), int(y1), int(x2), int(y2)) for x1, y1, x2, y2 in matches if int(y1) > 2200]
+            bottom_buttons = [(int(x1), int(y1), int(x2), int(y2)) for x1, y1, x2, y2 in matches if int(y1) > bottom_threshold]
             if bottom_buttons:
                 # Rightmost = highest x1
                 send_btn = max(bottom_buttons, key=lambda b: b[0])
@@ -372,9 +374,11 @@ def execute_action(action: dict) -> str:
                 cy = (send_btn[1] + send_btn[3]) // 2
                 adb("shell", "input", "tap", str(cx), str(cy))
                 return f"send button tapped ({cx}, {cy})"
-        # Fallback: tap known location
-        adb("shell", "input", "tap", "996", "2358")
-        return "send button tapped (fallback 996, 2358)"
+        # Fallback: tap bottom-right corner of the screen, offset slightly inward
+        fx = screen_w - 80
+        fy = screen_h - 120
+        adb("shell", "input", "tap", str(fx), str(fy))
+        return f"send button tapped (fallback {fx}, {fy})"
 
     elif act == "wait":
         secs = float(action.get("seconds", 2))

--- a/scripts/android-cua-smoke.py
+++ b/scripts/android-cua-smoke.py
@@ -620,6 +620,22 @@ def _connect_and_verify_sessions_goal(url: str) -> str:
     )
 
 
+def _connect_and_verify_existing_sessions_goal(url: str) -> str:
+    return (
+        f"You see the OpenCode mobile app. "
+        "Go to the Connections tab (bottom navigation bar). "
+        "If a connection to the server already exists, tap it to make it active and skip to the next step. "
+        "Otherwise tap '+' or 'Add Connection', "
+        f"enter the URL '{url}', leave username/password blank, tap Save or Connect. "
+        "Wait 3 seconds. "
+        "Now navigate to the Sessions tab (bottom navigation bar). "
+        "Wait 5 seconds for sessions to load. "
+        "Do NOT create a new session. Do NOT tap the '+' button. This scenario verifies whether existing sessions load immediately after connect. "
+        "Report SUCCESS only if you see at least one pre-existing session listed without creating a new one. "
+        "Report FAILURE if the sessions list is empty, shows 'No sessions yet', shows an error, or only becomes non-empty after creating a new session."
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Android CUA smoke test")
     parser.add_argument("--goal", help="Custom goal (overrides built-in scenarios)")
@@ -646,8 +662,8 @@ def main():
     parser.add_argument(
         "--scenarios",
         help="Comma-separated explicit scenario set to run, e.g. "
-             "'connect_and_verify_sessions,send_message,verify_session_list'. "
-             "Valid names: connect_and_verify_sessions, send_message, multi_turn, "
+             "'connect_and_verify_existing_sessions,send_message,verify_session_list'. "
+             "Valid names: connect_and_verify_existing_sessions, connect_and_verify_sessions, send_message, multi_turn, "
              "verify_session_list. Overrides --only-connect-scenario and the default set.",
     )
     args = parser.parse_args()
@@ -665,10 +681,17 @@ def main():
         "name": "connect_and_verify_sessions",
         "goal": _connect_and_verify_sessions_goal(connect_url),
     }
+    connect_existing_scenario = {
+        "name": "connect_and_verify_existing_sessions",
+        "goal": _connect_and_verify_existing_sessions_goal(connect_url),
+    }
 
     if args.scenarios:
         # Explicit named set (CI widened gate). Look up by name across the full catalog.
-        catalog = {connect_scenario["name"]: connect_scenario}
+        catalog = {
+            connect_existing_scenario["name"]: connect_existing_scenario,
+            connect_scenario["name"]: connect_scenario,
+        }
         for s in SMOKE_SCENARIOS:
             catalog[s["name"]] = s
         requested = [n.strip() for n in args.scenarios.split(",") if n.strip()]
@@ -679,12 +702,12 @@ def main():
         scenarios = [catalog[n] for n in requested]
     elif args.only_connect_scenario:
         # CI true-E2E: just connect to the local opencode server and verify the list.
-        scenarios = [connect_scenario]
+        scenarios = [connect_existing_scenario]
     else:
         scenarios = [{"name": "custom", "goal": args.goal}] if args.goal else list(SMOKE_SCENARIOS)
         # Keep connect-and-verify in the default smoke path so regressions are exercised.
         if not args.goal and not args.skip_connect_scenario:
-            scenarios.append(connect_scenario)
+            scenarios.append(connect_existing_scenario)
 
     results = []
     for scenario in scenarios:

--- a/scripts/android-cua-smoke.py
+++ b/scripts/android-cua-smoke.py
@@ -361,20 +361,21 @@ def execute_action(action: dict) -> str:
         # Threshold is screen-relative (bottom 25%) so it works on any emulator
         # resolution — API 30 default profile is 1080x1920, not the 2400-tall pixel
         # we previously hardcoded against.
-        screen_w, screen_h = get_screen_size()
+        _, screen_h = get_screen_size()
         bottom_threshold = int(screen_h * 0.75)
         xml = ui_dump()
         matches = re.findall(r'clickable="true"[^>]*bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"', xml)
         if matches:
             bottom_buttons = [(int(x1), int(y1), int(x2), int(y2)) for x1, y1, x2, y2 in matches if int(y1) > bottom_threshold]
             if bottom_buttons:
-                # Rightmost = highest x1
-                send_btn = max(bottom_buttons, key=lambda b: b[0])
+                # Rightmost = highest center-x (not left-edge x1, which misidentifies wide buttons)
+                send_btn = max(bottom_buttons, key=lambda b: (b[0] + b[2]) // 2)
                 cx = (send_btn[0] + send_btn[2]) // 2
                 cy = (send_btn[1] + send_btn[3]) // 2
                 adb("shell", "input", "tap", str(cx), str(cy))
                 return f"send button tapped ({cx}, {cy})"
         # Fallback: tap bottom-right corner of the screen, offset slightly inward
+        screen_w, _ = get_screen_size()
         fx = screen_w - 80
         fy = screen_h - 120
         adb("shell", "input", "tap", str(fx), str(fy))
@@ -602,8 +603,15 @@ SMOKE_SCENARIOS = [
 
 # Extended scenarios requiring an external OpenCode server.
 # Run with: python scripts/android-cua-smoke.py --opencode-url http://<host>:<port>
-def _connect_and_verify_sessions_goal(url: str) -> str:
-    return (
+def _connect_and_verify_sessions_goal(url: str, allow_create: bool = True) -> str:
+    """Build a connect-and-verify goal string.
+
+    When allow_create=True (default): if no sessions exist the agent may tap '+' to
+    create one (self-healing, used by the legacy scenario).
+    When allow_create=False: the agent must find pre-existing sessions and must NOT
+    create any (strict regression gate used by the default CI scenario).
+    """
+    base = (
         f"You see the OpenCode mobile app. "
         "Go to the Connections tab (bottom navigation bar). "
         "If a connection to the server already exists, tap it to make it active and skip to the next step. "
@@ -612,28 +620,27 @@ def _connect_and_verify_sessions_goal(url: str) -> str:
         "Wait 3 seconds. "
         "Now navigate to the Sessions tab (bottom navigation bar). "
         "Wait 5 seconds for sessions to load. "
-        "If the sessions list is empty or shows 'No sessions yet', tap the '+' button "
-        "(top-right) to create a new session, wait 3 seconds, then navigate back to the "
-        "Sessions tab and wait 3 seconds for the list to refresh. "
-        "Report SUCCESS if you see at least one session listed (a session title is visible). "
-        "Report FAILURE if the sessions list is still empty, shows 'No sessions yet', or shows an error."
     )
+    if allow_create:
+        return (
+            base
+            + "If the sessions list is empty or shows 'No sessions yet', tap the '+' button "
+            "(top-right) to create a new session, wait 3 seconds, then navigate back to the "
+            "Sessions tab and wait 3 seconds for the list to refresh. "
+            "Report SUCCESS if you see at least one session listed (a session title is visible). "
+            "Report FAILURE if the sessions list is still empty, shows 'No sessions yet', or shows an error."
+        )
+    else:
+        return (
+            base
+            + "Do NOT create a new session. Do NOT tap the '+' button. This scenario verifies whether existing sessions load immediately after connect. "
+            "Report SUCCESS only if you see at least one pre-existing session listed without creating a new one. "
+            "Report FAILURE if the sessions list is empty, shows 'No sessions yet', shows an error, or only becomes non-empty after creating a new session."
+        )
 
 
 def _connect_and_verify_existing_sessions_goal(url: str) -> str:
-    return (
-        f"You see the OpenCode mobile app. "
-        "Go to the Connections tab (bottom navigation bar). "
-        "If a connection to the server already exists, tap it to make it active and skip to the next step. "
-        "Otherwise tap '+' or 'Add Connection', "
-        f"enter the URL '{url}', leave username/password blank, tap Save or Connect. "
-        "Wait 3 seconds. "
-        "Now navigate to the Sessions tab (bottom navigation bar). "
-        "Wait 5 seconds for sessions to load. "
-        "Do NOT create a new session. Do NOT tap the '+' button. This scenario verifies whether existing sessions load immediately after connect. "
-        "Report SUCCESS only if you see at least one pre-existing session listed without creating a new one. "
-        "Report FAILURE if the sessions list is empty, shows 'No sessions yet', shows an error, or only becomes non-empty after creating a new session."
-    )
+    return _connect_and_verify_sessions_goal(url, allow_create=False)
 
 
 def main():


### PR DESCRIPTION
## Summary
- Make CUA sessions regression test non-mutating (read-only verification)
- Includes commits from fix/cua-azure-api-version-22 as base

## Test Plan
- [ ] Run CUA regression test suite
- [ ] Verify no side effects on session state