### PR TITLE
fix(sessions): scope default to server CWD, not $HOME (#32)

### DIFF
--- a/src/stores/sessionScope.test.ts
+++ b/src/stores/sessionScope.test.ts
@@ -3,10 +3,12 @@ import assert from "node:assert/strict"
 import { sessionScopeDirectory } from "./sessionScope.ts"
 
 // Bug #10 regression guard: list and create must resolve to the SAME scope.
-// These cases pin the shared rule both call sites rely on.
+// Bug #32 regression guard: the default scope must be "no header" (null), not
+// the server's home directory. The home dir resolves to the "global" project on
+// the opencode server and hides real workspace sessions.
 
-test("no explicit directory + known home -> scope to home", () => {
-  assert.equal(sessionScopeDirectory(false, "/home/user"), "/home/user")
+test("no explicit directory + known home -> default client (null), home ignored (#32)", () => {
+  assert.equal(sessionScopeDirectory(false, "/home/user"), null)
 })
 
 test("no explicit directory + unknown home -> default client (null)", () => {
@@ -20,7 +22,7 @@ test("explicit directory -> default client (null), home ignored", () => {
   assert.equal(sessionScopeDirectory(true, null), null)
 })
 
-test("create and list resolve identically across all inputs (no drift)", () => {
+test("create and list resolve identically across all inputs (no drift, #10)", () => {
   for (const hasDir of [true, false]) {
     for (const home of ["/home/user", null, undefined, ""]) {
       const listScope = sessionScopeDirectory(hasDir, home)
@@ -28,4 +30,11 @@ test("create and list resolve identically across all inputs (no drift)", () => {
       assert.equal(listScope, createScope)
     }
   }
+})
+
+test("server directory != home: rule returns null so server uses its CWD project (#32)", () => {
+  // Reproduces the real-world setup: server launched in ~/workspace/opencode
+  // while $HOME is /home/azureuser. Old rule returned "/home/azureuser" (global
+  // project, empty). New rule returns null so server uses its CWD project.
+  assert.equal(sessionScopeDirectory(false, "/home/azureuser"), null)
 })

--- a/src/stores/sessionScope.ts
+++ b/src/stores/sessionScope.ts
@@ -6,11 +6,21 @@
 // a freshly created session was invisible. Both call sites now derive their client
 // from this one function, so they cannot disagree again.
 //
+// Bug #32 ("recent sessions missing"): the previous rule scoped to the server's
+// home directory when no explicit directory was set. opencode-server resolves the
+// x-opencode-directory header to a project id by exact-match, NOT subtree prefix.
+// $HOME typically maps to the synthetic "global" project, which never contains
+// the user's real workspace sessions (those live under e.g. ~/workspace/foo, a
+// different project id). The list looked empty even when sessions existed.
+//
 // Rule: when the active connection pins an explicit directory, use the default
-// client (it is already scoped to that directory). Otherwise, if we know the
-// server's home directory, scope to it. If home is unknown, fall back to default.
+// client (it is already scoped to that directory). Otherwise, send no scope at
+// all so the server uses its own CWD — i.e. the project where opencode serve was
+// launched, which is the project the user actually works in. The `home` argument
+// is accepted for backward compatibility but intentionally ignored.
 
-export function sessionScopeDirectory(hasExplicitDirectory: boolean, home: string | null | undefined): string | null {
+export function sessionScopeDirectory(hasExplicitDirectory: boolean, _home?: string | null | undefined): string | null {
+  void _home
   if (hasExplicitDirectory) return null
-  return home ? home : null
+  return null
 }


### PR DESCRIPTION
## Summary
- Fixes #32: recent (last-24h) sessions missing from the Android session list when `opencode serve` is launched outside `$HOME` (e.g. `~/workspace/opencode`).
- Root cause: `sessionScopeDirectory` defaulted to the server's home dir. opencode-server resolves `x-opencode-directory` to a project id by **exact-match**, not subtree prefix, so `$HOME` mapped to the synthetic `global` project — which never contained the user's workspace sessions.
- Change: drop the home-fallback. When no explicit directory is set, return `null` (no header) and let the server use its own CWD project — the same project sessions are actually created in.

## Why this preserves #10
Both `loadSessions` and `createSession` still derive scope from `sessionScopeDirectory`, so they cannot drift. The drift cure is intact; only the rule changed.

## Verification
**Unit:** 69/69 tests green (`src/stores/sessionScope.test.ts` extended with a #32 regression case).

**Live server (`http://100.108.64.76:4096/`):**
```
scope=null  (new): 39 sessions; top hits = Opencode npm install failure, Fix autopilot_exit, ...
scope=$HOME (old): 29 sessions; top hits = generic chats only (global project)
```
The new rule surfaces the workspace sessions the user expects to see.

## Touched
- `src/stores/sessionScope.ts` — rule returns `null` when no explicit directory; `home` arg kept for backward compat but ignored, with rationale comment.
- `src/stores/sessionScope.test.ts` — added #32 regression test; updated existing case that asserted the old (wrong) home-scope.

Closes #32