### PR TITLE
fix(android): keyboard covers text input on chat screen

### DIFF
--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -483,7 +483,7 @@ export default function SessionScreen() {
 
       <KeyboardAvoidingView
         style={[s.container, isDark && s.containerDark]}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
       >
         {/* Session info pulldown */}


### PR DESCRIPTION
## Description

Fixes the keyboard covering the text input on the Android chat screen.

## Root Cause

KeyboardAvoidingView used behavior="height" on Android, which conflicts with the native android:windowSoftInputMode="adjustResize" already configured in AndroidManifest.xml. This caused the keyboard to overlap the input instead of pushing it up.

## Fix

Changed behavior from "height" to undefined on Android. On Android, this lets the native adjustResize handling work without interference — the standard recommended approach.

## Changes

- app/session/[id].tsx: line 486 — KeyboardAvoidingView behavior

Closes #53
