### PR TITLE
Fix existing session open and strengthen CUA regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencode-ai/mobile",
-  "version": "0.4.3",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencode-ai/mobile",
-      "version": "0.4.3",
+      "version": "0.4.7",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "5.2.8",


### PR DESCRIPTION
Fixes #46 by ensuring sessions list uses the active connection client so pre-existing sessions are visible and can be opened, and by tightening the Android CUA showcase regression to require a pre-created session in the list.