### PR TITLE
fix(android): prevent keyboard from covering chat input

### DIFF
--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -483,7 +483,7 @@ export default function SessionScreen() {
 
       <KeyboardAvoidingView
         style={[s.container, isDark && s.containerDark]}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
       >
         {/* Session info pulldown */}


### PR DESCRIPTION
## Summary

Carries forward the valid one-line fix from contributor PR #54 on top of current `main`, preserving Pedro Castro’s authorship. Android now relies on the activity’s existing `adjustResize` behavior instead of applying an additional keyboard-avoidance height offset; iOS remains unchanged.

Supersedes #54 because the fork branch cannot be updated by the current GitHub OAuth token after workflow files were added to `main`.

## Verification

- [ ] Android build CI
- [ ] iOS CI
- [ ] Mandatory CUA smoke test

Closes #54