### PR TITLE
fix(android): stop keyboard covering chat input

### DIFF
--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -483,7 +483,11 @@ export default function SessionScreen() {
 
       <KeyboardAvoidingView
         style={[s.container, isDark && s.containerDark]}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        // "height" fights the native android:windowSoftInputMode="adjustResize"
+        // already set in AndroidManifest.xml, which causes the keyboard to
+        // overlap the text input instead of pushing it up (#53). Let the
+        // native resize handle it on Android.
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
       >
         {/* Session info pulldown */}


### PR DESCRIPTION
## Problem
On Android, the on-screen keyboard covers the chat text input, so the user can't see what they're typing (#53).

## Root cause
`KeyboardAvoidingView` in `app/session/[id].tsx` used `behavior="height"` on Android, which conflicts with the native `android:windowSoftInputMode="adjustResize"` already declared in `AndroidManifest.xml`. `"height"` is known to be unreliable on Android, especially with `FlatList`/nested scrolling.

## Fix
Change `behavior={Platform.OS === "ios" ? "padding" : "height"}` to `behavior={Platform.OS === "ios" ? "padding" : undefined}`, letting the native `adjustResize` window mode handle keyboard avoidance on Android — the fix proposed directly in the issue.

## Test plan
- [x] `npm run typecheck` passes
- [ ] Manual/CUA verification on an Android device or emulator: open a session, tap the text input, confirm the input remains visible above the keyboard

Fixes #53