### PR TITLE
fix(sessions): hide misleading "0 files" in session list

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -78,7 +78,10 @@ function SessionItem({
         <View style={styles.sessionMetaRow}>
           <Text style={[styles.sessionMeta, isDark && styles.metaDark]}>
             {formatTime(session.time.updated)}
-            {session.summary && ` · ${session.summary.files} files`}
+            {/* summary is always present but files defaults to 0 until the
+                server populates it — only show the count when it's meaningful,
+                matching the SessionInfo panel's `summary.files > 0` guard (#55) */}
+            {session.summary && session.summary.files > 0 && ` · ${session.summary.files} files`}
           </Text>
           {shortDir && (
             <View style={styles.sessionDirBadge}>


### PR DESCRIPTION
## Problem
The session list always shows "· 0 files" regardless of how many files a session actually touched (#55).

## Root cause
`session.summary` is a truthy object with `files` defaulting to `0` until the server populates real counts, so `session.summary && ... files` in `app/(tabs)/index.tsx` always renders. `src/components/chat/SessionInfo.tsx` already avoids this by guarding on `summary.files > 0`.

## Fix (partial)
Apply the same `summary.files > 0` guard to the session list so it stops displaying a count that is never accurate.

## What this does NOT fix
This does not make the file count itself correct. `session.summary` is populated server-side, and the `opencode` server currently never updates it after a session runs (per the issue's own root-cause analysis). Producing real counts needs either:
1. A server-side fix in the `opencode` server to populate `summary` after tool use, or
2. Client-side aggregation from session message parts (edit/write tool calls) — meaningfully more work and, for the session list specifically, would require fetching messages for every visible session (N+1 requests), which is likely why the server was expected to precompute this in the first place.

Filing/tracking the server-side fix is out of scope for this repo. This PR only removes the misleading always-zero text as a low-risk interim improvement.

## Test plan
- [x] `npm run typecheck` passes
- [ ] Manual verification: session list no longer shows "0 files" for any session

Partially addresses #55