### PR TITLE
fix: open sessions from non-active projects (thread directory through session route)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -49,7 +49,15 @@ function SessionItem({
   onDelete: () => void
 }) {
   const onPress = () => {
-    router.push(`/session/${session.id}`)
+    // Thread the session's directory through the route so selectSession() can
+    // resolve a directory-scoped client (clientForDirectory) instead of
+    // falling back to the active connection's default client. Without this,
+    // opening a session that belongs to a non-active project silently fails
+    // (see onCreateSession / onCreateInDirectory, which already pass it).
+    router.push({
+      pathname: `/session/[id]`,
+      params: { id: session.id, ...(session.directory ? { directory: session.directory } : {}) },
+    })
   }
 
   const onLongPress = () => {


### PR DESCRIPTION
## Root cause
`SessionItem`'s `onPress` in `app/(tabs)/index.tsx` navigated with
`router.push(\`/session/${session.id}\`)`, without the session's
`directory` — unlike `onCreateSession`/`onCreateInDirectory`, which
already pass `directory` as a route param.

`selectSession()` in `src/stores/sessions.ts` uses
`connState.clientForDirectory(directory)` when a directory is given,
and otherwise falls back to the active connection's default client.
Without the directory param, opening any session belonging to a
project other than the currently active one used the wrong client:
`client.session.get()` / `client.session.messages()` silently failed
(wrong project scope) and the chat screen never opened.

## Fix
Mirror the existing create-session pattern in `SessionItem.onPress`:
pass `session.directory` through `router.push` params, exactly like
`onCreateSession` / `onCreateInDirectory` already do. No changes were
needed in `app/session/[id].tsx` or `src/stores/sessions.ts` — both
already accept and correctly use a `directory` param
(`selectSession(id, directory)` → `clientForDirectory(directory)`);
the tap handler simply wasn't supplying it.

## Scope note
`app/_layout.tsx`'s notification-tap handler (`router.push(\`/session/${data.sessionId}\`)`)
has the same shape but the push payload carries no `directory` field
at all — fixing that would require a server/payload change and is out
of scope for this issue.

## Testing
- `npm run typecheck` — clean
- `npm test` — 108/108 passing
- UI-only routing change; no pure helper introduced, so no new unit test added

Closes #46