### PR TITLE
fix(auth): stop infinite SSE retry on 401/403, surface auth failures

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -19,6 +19,7 @@ import { router, useFocusEffect } from "expo-router"
 import { Ionicons } from "@expo/vector-icons"
 import { useSessions } from "../../src/stores/sessions"
 import { useConnections } from "../../src/stores/connections"
+import { useEvents } from "../../src/stores/events"
 import { useCatalog } from "../../src/stores/catalog"
 import type BottomSheet from "@gorhom/bottom-sheet"
 import type { Session, Project } from "../../src/lib/sdk"
@@ -133,6 +134,7 @@ export default function SessionsScreen() {
     addRecentDirectory,
     recentDirectories,
   } = useConnections()
+  const authError = useEvents((s) => s.authError)
   const loadCatalog = useCatalog((s) => s.load)
   const dirSheetRef = useRef<BottomSheet>(null)
   const browserSheetRef = useRef<BottomSheet>(null)
@@ -343,6 +345,29 @@ export default function SessionsScreen() {
           testID="add-connection-button"
         >
           <Text style={[styles.addButtonText, isDark && styles.addButtonTextDark]}>Add Connection</Text>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+
+  // The SSE loop stopped retrying because the server rejected our
+  // credentials (401/403) — no amount of pull-to-refresh fixes that, so
+  // point the user straight at the fix instead of a spinner that never
+  // resolves (issue #76).
+  if (authError) {
+    return (
+      <View style={[styles.emptyContainer, isDark && styles.containerDark]}>
+        <Ionicons name="lock-closed-outline" size={64} color={isDark ? "#444444" : "#cccccc"} />
+        <Text style={[styles.emptyTitle, isDark && styles.textDark]}>Authentication Failed</Text>
+        <Text style={[styles.emptySubtitle, isDark && styles.metaDark]}>
+          {activeConnection.name} rejected your credentials. Check the username and password to reconnect.
+        </Text>
+        <TouchableOpacity
+          style={[styles.addButton, isDark && styles.addButtonDark]}
+          onPress={() => router.push(`/connection/${activeConnection.id}`)}
+          testID="fix-connection-button"
+        >
+          <Text style={[styles.addButtonText, isDark && styles.addButtonTextDark]}>Check Credentials</Text>
         </TouchableOpacity>
       </View>
     )

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -135,6 +135,7 @@ export default function SessionsScreen() {
     recentDirectories,
   } = useConnections()
   const authError = useEvents((s) => s.authError)
+  const reconnect = useEvents((s) => s.connect)
   const loadCatalog = useCatalog((s) => s.load)
   const dirSheetRef = useRef<BottomSheet>(null)
   const browserSheetRef = useRef<BottomSheet>(null)
@@ -362,13 +363,27 @@ export default function SessionsScreen() {
         <Text style={[styles.emptySubtitle, isDark && styles.metaDark]}>
           {activeConnection.name} rejected your credentials. Check the username and password to reconnect.
         </Text>
-        <TouchableOpacity
-          style={[styles.addButton, isDark && styles.addButtonDark]}
-          onPress={() => router.push(`/connection/${activeConnection.id}`)}
-          testID="fix-connection-button"
-        >
-          <Text style={[styles.addButtonText, isDark && styles.addButtonTextDark]}>Check Credentials</Text>
-        </TouchableOpacity>
+        <View style={styles.authErrorButtonRow}>
+          <TouchableOpacity
+            style={[styles.addButton, isDark && styles.addButtonDark]}
+            onPress={() => router.push(`/connection/${activeConnection.id}`)}
+            testID="fix-connection-button"
+          >
+            <Text style={[styles.addButtonText, isDark && styles.addButtonTextDark]}>Check Credentials</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.addButton, isDark && styles.addButtonDark]}
+            onPress={() => {
+              // authError is cleared inside connect() itself once the retry
+              // attempt starts (see src/stores/events.ts), so a manual
+              // set() here isn't needed — just kick the SSE state machine.
+              reconnect()
+            }}
+            testID="retry-connection-button"
+          >
+            <Text style={[styles.addButtonText, isDark && styles.addButtonTextDark]}>Retry</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     )
   }
@@ -856,6 +871,10 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderRadius: 8,
     marginTop: 24,
+  },
+  authErrorButtonRow: {
+    flexDirection: "row",
+    gap: 12,
   },
   addButtonDark: {
     backgroundColor: "#ffffff",

--- a/app/connection/[id].tsx
+++ b/app/connection/[id].tsx
@@ -13,6 +13,7 @@ import {
 import { router, useLocalSearchParams } from "expo-router"
 import { Ionicons } from "@expo/vector-icons"
 import { useConnections } from "../../src/stores/connections"
+import { useEvents } from "../../src/stores/events"
 import type { ConnectionType } from "../../src/lib/types"
 import { probeConnection, shareReport } from "../../src/lib/diagnostics"
 import { captureDiagnostic } from "../../src/lib/sentry"
@@ -130,6 +131,13 @@ export default function EditConnectionScreen() {
       directory: directory.trim() || undefined,
       username: username.trim() || undefined,
     })
+    // If this was the active connection, the SSE loop may have stopped
+    // retrying after a prior 401 (see events.ts) — reconnect now with the
+    // freshly saved credentials instead of leaving the user stuck until
+    // they relaunch the app.
+    if (useConnections.getState().activeConnection?.id === connection.id) {
+      useEvents.getState().connect()
+    }
     setIsSaving(false)
     router.back()
   }

--- a/app/connection/add.tsx
+++ b/app/connection/add.tsx
@@ -133,23 +133,59 @@ export default function AddConnectionScreen() {
     }
 
     track(AnalyticsEvent.ConnectionFormSubmitted, { mode: "advanced" })
-    // Advanced mode saves directly without a pre-flight health check (see
-    // useConnections.addConnection), so unlike quick-connect there is no
-    // success/failure signal to report here — only that an attempt was made.
-    track(AnalyticsEvent.ConnectionAttempted, { source: "onboarding" })
     setIsConnecting(true)
-    await addConnection(
+
+    // Pre-flight, mirroring Quick Connect: previously Advanced mode saved
+    // directly with no health check, so bad credentials (401/403) or an
+    // unreachable server silently became the active connection with zero
+    // feedback (issue #76). testConnection() also fires the
+    // connection_attempted/succeeded/failed analytics events.
+    const result = await testConnection(
       {
+        id: "",
         name: name.trim(),
         type,
         url: url.trim(),
         directory: directory.trim() || undefined,
         username: username.trim() || undefined,
       },
+      "onboarding",
       password || undefined,
     )
+
+    if (result.ok) {
+      await addConnection(
+        {
+          name: name.trim(),
+          type,
+          url: url.trim(),
+          directory: directory.trim() || undefined,
+          username: username.trim() || undefined,
+        },
+        password || undefined,
+      )
+      setIsConnecting(false)
+      router.back()
+      return
+    }
+
+    // Failed: same "Connection Failed" alert as Quick Connect — run active
+    // diagnostics, capture to Sentry, and offer a shareable report instead of
+    // silently persisting an unreachable/unauthorized connection.
+    const report = await probeConnection(
+      url.trim(),
+      username.trim() && password ? { username: username.trim(), password } : undefined,
+    )
+    captureDiagnostic(report)
     setIsConnecting(false)
-    router.back()
+    Alert.alert(
+      "Connection Failed",
+      `${report.summary}\n\nTarget: ${url.trim()}\nError: ${result.error || "Unknown error"}`,
+      [
+        { text: "OK", style: "cancel" },
+        { text: "Share report", onPress: () => shareReport(report) },
+      ],
+    )
   }
 
   const handleJoinWaitlist = async () => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -87,11 +87,12 @@ export enum AnalyticsEvent {
   ResponseReceived = "response_received",
 }
 
-/** Where a connection test was initiated from. The activation funnel filters
- *  to source=onboarding; edit_test covers the Test button on the existing-
- *  connection edit screen, which would otherwise pollute the funnel with
- *  repeat-tester noise. */
-export type ConnectionTestSource = "onboarding" | "edit_test"
+/** Where a connection test/failure was initiated from. The activation funnel
+ *  filters to source=onboarding only; edit_test (Test button on the
+ *  existing-connection edit screen) and sse (background reconnect loop,
+ *  see events.ts) would otherwise pollute the funnel with repeat-tester and
+ *  post-activation noise. */
+export type ConnectionTestSource = "onboarding" | "edit_test" | "sse"
 
 export function initAnalytics() {
   if (enabled) return

--- a/src/lib/api-error.test.ts
+++ b/src/lib/api-error.test.ts
@@ -1,0 +1,42 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { ApiAuthError, apiErrorFor, isAuthError, isAuthStatus } from "./api-error.ts"
+
+test("isAuthStatus: 401 and 403 are auth failures", () => {
+  assert.equal(isAuthStatus(401), true)
+  assert.equal(isAuthStatus(403), true)
+})
+
+test("isAuthStatus: other statuses are not auth failures", () => {
+  assert.equal(isAuthStatus(200), false)
+  assert.equal(isAuthStatus(404), false)
+  assert.equal(isAuthStatus(500), false)
+  assert.equal(isAuthStatus(503), false)
+  assert.equal(isAuthStatus(0), false)
+})
+
+test("apiErrorFor: 401/403 produce an ApiAuthError carrying the status", () => {
+  const err401 = apiErrorFor(401, "API Error: 401 - Unauthorized")
+  assert.ok(err401 instanceof ApiAuthError)
+  assert.equal(err401.status, 401)
+  assert.equal(err401.message, "API Error: 401 - Unauthorized")
+
+  const err403 = apiErrorFor(403, "API Error: 403 - Forbidden")
+  assert.ok(err403 instanceof ApiAuthError)
+  assert.equal(err403.status, 403)
+})
+
+test("apiErrorFor: other statuses produce a plain Error, not ApiAuthError", () => {
+  const err = apiErrorFor(500, "API Error: 500 - Internal Server Error")
+  assert.ok(err instanceof Error)
+  assert.equal(err instanceof ApiAuthError, false)
+  assert.equal(err.message, "API Error: 500 - Internal Server Error")
+})
+
+test("isAuthError: type guard matches only ApiAuthError instances", () => {
+  assert.equal(isAuthError(new ApiAuthError(401, "nope")), true)
+  assert.equal(isAuthError(new Error("some other error")), false)
+  assert.equal(isAuthError("401"), false)
+  assert.equal(isAuthError(undefined), false)
+  assert.equal(isAuthError(null), false)
+})

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,38 @@
+// Pure classification of HTTP auth failures, extracted so it's unit-testable
+// under plain `node --test` without pulling in expo/fetch (sdk.ts is RN-only)
+// — same pattern as analytics-classify.ts / diagnostics-classify.ts.
+//
+// Why this exists: sdk.ts's request()/events() used to throw a generic Error
+// for every non-2xx response, so call sites (the SSE reconnect loop, screen
+// error states) had no way to tell "your password is wrong" apart from "the
+// server is briefly unreachable" — a 401 got treated like any transient
+// failure and retried forever (see events.ts's reconnect loop / issue #76).
+
+/** Thrown by sdk.ts's request()/events() when the server responds 401/403,
+ *  so call sites can distinguish "bad credentials" from any other failure
+ *  (network error, 5xx, timeout) instead of catching a generic Error. */
+export class ApiAuthError extends Error {
+  readonly status: number
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = "ApiAuthError"
+    this.status = status
+  }
+}
+
+/** True for HTTP statuses that mean "your credentials are wrong", as opposed
+ *  to transient/network/server failures that should keep retrying. */
+export function isAuthStatus(status: number): boolean {
+  return status === 401 || status === 403
+}
+
+/** Build the right error type for a failed HTTP response. */
+export function apiErrorFor(status: number, message: string): Error {
+  return isAuthStatus(status) ? new ApiAuthError(status, message) : new Error(message)
+}
+
+/** Type guard for call sites (e.g. the SSE reconnect loop) that need to branch
+ *  on whether a caught error was an auth failure. */
+export function isAuthError(error: unknown): error is ApiAuthError {
+  return error instanceof ApiAuthError
+}

--- a/src/lib/sdk.ts
+++ b/src/lib/sdk.ts
@@ -5,6 +5,9 @@
 import { fetch as expoFetch } from "expo/fetch"
 import { buildRequestHeaders } from "./headers"
 import { SSEParser } from "./sse"
+import { apiErrorFor } from "./api-error"
+
+export { ApiAuthError, isAuthError } from "./api-error"
 
 export interface ClientConfig {
   baseUrl: string
@@ -196,7 +199,7 @@ async function request<T>(config: ClientConfig, path: string, options: RequestIn
 
   if (!response.ok) {
     const error = await response.text()
-    throw new ApiError(response.status, error)
+    throw apiErrorFor(response.status, `API Error: ${response.status} - ${error}`)
   }
 
   return response.json()
@@ -243,7 +246,7 @@ export function createClient(config: ClientConfig) {
         // Must use expo/fetch for ReadableStream support on native
         const response = await expoFetch(url, { headers, signal })
         if (!response.ok || !response.body) {
-          throw new Error(`Failed to connect to event stream: ${response.status}`)
+          throw apiErrorFor(response.status, `Failed to connect to event stream: ${response.status}`)
         }
 
         const reader = response.body.getReader()

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -7,6 +7,7 @@ import { statusFromPart } from "../lib/status-labels"
 import { addBreadcrumb } from "../lib/sentry"
 import { AnalyticsEvent, track } from "../lib/analytics"
 import { recordSuccessfulSession } from "../lib/store-review"
+import { isAuthError } from "../lib/api-error"
 import type { Client, Part, Session, Message } from "../lib/sdk"
 
 // Session status from the server
@@ -14,6 +15,13 @@ type SessionStatus = { type: "idle" } | { type: "busy" } | { type: "retry"; atte
 
 interface EventsState {
   connected: boolean
+  // Set when the last connection attempt failed with 401/403 — the server
+  // rejected our credentials, not a transient network issue. The reconnect
+  // loop stops retrying in this case (see connect()) since hammering a
+  // fixed-credential auth failure forever just spams Sentry/battery with no
+  // path to recovery (issue #76). Cleared on the next connect() attempt,
+  // e.g. after the user fixes their credentials on the connection edit screen.
+  authError: boolean
   reconnectAttempts: number
   lastDisconnectAt: number | null
   sessionStatus: Record<string, SessionStatus>
@@ -82,6 +90,7 @@ export async function refreshPending(client: Client, sessionID: string) {
 
 export const useEvents = create<EventsState>((set, get) => ({
   connected: false,
+  authError: false,
   reconnectAttempts: 0,
   lastDisconnectAt: null,
   sessionStatus: {},
@@ -102,7 +111,7 @@ export const useEvents = create<EventsState>((set, get) => ({
 
     controller = new AbortController()
     const currentController = controller
-    set({ connected: true })
+    set({ connected: true, authError: false })
     console.log("[SSE] Connecting to event stream...")
     addBreadcrumb({ category: "sse", message: "connecting" })
 
@@ -364,7 +373,24 @@ export const useEvents = create<EventsState>((set, get) => ({
 
         scheduleReconnect(new Error("Event stream closed"))
       } catch (err) {
-        scheduleReconnect(err)
+        if (isAuthError(err) && !currentController.signal.aborted) {
+          // Bad credentials, not a transient failure — retrying forever just
+          // spams Sentry and drains the battery with zero path to recovery
+          // (issue #76: 309 events / 65 users). Stop and surface a distinct
+          // state instead; the sessions screen offers a link to fix
+          // credentials, which reconnects via connect() once saved.
+          console.warn("[SSE] Authentication failed — stopping reconnect loop:", err)
+          addBreadcrumb({
+            category: "sse",
+            level: "error",
+            message: "auth error - stopped retrying",
+            data: { status: err.status },
+          })
+          track(AnalyticsEvent.ConnectionFailed, { source: "sse", error_class: "unauthorized" })
+          set({ connected: false, authError: true })
+        } else {
+          scheduleReconnect(err)
+        }
       } finally {
         clearTimeout(stableTimer)
         if (currentController.signal.aborted) {
@@ -387,6 +413,7 @@ export const useEvents = create<EventsState>((set, get) => ({
     abortedSessions.clear()
     set({
       connected: false,
+      authError: false,
       reconnectAttempts: 0,
       lastDisconnectAt: null,
       sessionStatus: {},


### PR DESCRIPTION
## Root cause

Sentry `OPENCODE-MOBILE-1`: 309 events / 65 users hitting a recurring `API Error: 401`. Auth is static HTTP Basic and no code path treated a 401/403 specially:

1. **`events.ts`'s SSE reconnect loop** retried forever on a fixed backoff regardless of failure cause — a bad password spammed Sentry and drained battery with zero user-visible feedback.
2. **Advanced-mode connection save** (`app/connection/add.tsx`) did no pre-flight check and silently persisted bad credentials as the active connection (unlike Quick Connect, which tests first).
3. **`request()`/`events()`** in `src/lib/sdk.ts` threw generic `Error`s, so call sites had no way to distinguish "bad credentials" from a transient network blip and just swallowed everything into inert UI state.

## Changes

- `src/lib/api-error.ts` (new): pure `ApiAuthError` / `isAuthStatus` / `isAuthError` — extracted from `sdk.ts` (which is RN-only via `expo/fetch`) so it's covered by plain `node --test`, same pattern as `analytics-classify.ts`.
- `src/lib/sdk.ts`: `request()` and `events()` now throw `ApiAuthError` (status 401/403) instead of a generic `Error`.
- `src/stores/events.ts`: the SSE loop stops retrying when it catches an `ApiAuthError`, sets a new `authError` flag, and fires the existing `connection_failed` analytics event (`source: "sse"`, `error_class: "unauthorized"`). Non-auth errors keep the existing backoff/retry behavior untouched.
- `app/(tabs)/index.tsx`: sessions screen renders an "Authentication Failed" state (mirroring the existing "No Connection" empty state) with a button to the connection edit screen when `authError` is set.
- `app/connection/[id].tsx`: saving edited credentials for the currently-active connection now calls `useEvents.getState().connect()` so SSE reconnects immediately — previously the fix required an app restart, since stopping the infinite retry loop also removed its side-effect of eventually picking up new credentials.
- `app/connection/add.tsx`: Advanced-mode save now runs the same `testConnection()` pre-flight as Quick Connect and, on failure, shows the identical "Connection Failed" alert (diagnostics + share report) instead of silently saving.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (113/113 passing, including 5 new `api-error.test.ts` cases)
- [ ] Manual: point a connection at a server with a wrong password, confirm SSE stops retrying and the sessions screen shows "Authentication Failed" instead of spamming reconnects
- [ ] Manual: fix the password on the edit screen, confirm the app reconnects without a restart
- [ ] Manual: Advanced-mode save with bad credentials shows "Connection Failed" instead of saving silently

Closes #76