### PR TITLE
fix(site): use support@agentlabs.cc for opencode-mobile support contact

### DIFF
--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -30,7 +30,7 @@ export default function PrivacyPage() {
     policyHtml = bodyMatch ? bodyMatch[1] : raw
   } catch {
     policyHtml = `<p style="color:#94A3B8">Privacy policy document not found. Please contact
-      <a href="mailto:support@vibebrowser.app" style="color:#3B82F6">support@vibebrowser.app</a>.</p>`
+      <a href="mailto:support@agentlabs.cc" style="color:#3B82F6">support@agentlabs.cc</a>.</p>`
   }
 
   return (

--- a/website/app/support/page.tsx
+++ b/website/app/support/page.tsx
@@ -48,7 +48,7 @@ export default function SupportPage() {
       {/* Contact cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-5 mb-16">
         <a
-          href="mailto:support@vibebrowser.app"
+          href="mailto:support@agentlabs.cc"
           className="card flex items-start gap-4 hover:border-blue-500/60 transition-colors"
           style={{ textDecoration: 'none' }}
         >
@@ -61,7 +61,7 @@ export default function SupportPage() {
           </div>
           <div>
             <p className="font-semibold mb-1" style={{ color: 'var(--fg)' }}>Email Support</p>
-            <p className="text-sm" style={{ color: 'var(--muted)' }}>support@vibebrowser.app</p>
+            <p className="text-sm" style={{ color: 'var(--muted)' }}>support@agentlabs.cc</p>
           </div>
         </a>
 
@@ -111,8 +111,8 @@ export default function SupportPage() {
           GitHub Issue
         </a>{' '}
         or email{' '}
-        <a href="mailto:support@vibebrowser.app" style={{ color: 'var(--accent)' }}>
-          support@vibebrowser.app
+        <a href="mailto:support@agentlabs.cc" style={{ color: 'var(--accent)' }}>
+          support@agentlabs.cc
         </a>.
         Include your device, OS version, and app version for fastest resolution.
       </div>

--- a/website/app/terms/page.tsx
+++ b/website/app/terms/page.tsx
@@ -128,7 +128,7 @@ export default function TermsPage() {
             GitHub Issues
           </a>{' '}
           and via{' '}
-          <a href="mailto:support@vibebrowser.app">support@vibebrowser.app</a>, but we make no
+          <a href="mailto:support@agentlabs.cc">support@agentlabs.cc</a>, but we make no
           guarantees about response times or resolution.
         </p>
         <p>
@@ -191,7 +191,7 @@ export default function TermsPage() {
           Seattle, WA 98108-4522<br />
           USA<br />
           Email:{' '}
-          <a href="mailto:support@vibebrowser.app">support@vibebrowser.app</a>
+          <a href="mailto:support@agentlabs.cc">support@agentlabs.cc</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

The research sweep found that app store listings, the privacy policy source, F-Droid metadata, and the in-app `mailto:` link all already use `support@agentlabs.cc`, but the **website's** Support/Privacy/Terms pages still showed `support@vibebrowser.app` — leftover boilerplate copied from the parent VibeBrowser product. This PR brings the website in line with the canonical `support@agentlabs.cc` address.

## Files changed (10 occurrences across 3 files)

- `website/app/support/page.tsx` — mailto `href` on the "Email Support" contact card, the visible address under it, and the mailto link + text in the "Still stuck?" footer callout.
- `website/app/privacy/page.tsx` — fallback contact string shown only if `distribution/privacy-policy.html` fails to load at build time (the primary policy content is generated elsewhere and already uses the correct address).
- `website/app/terms/page.tsx` — Section 7 ("No Support Obligation") support mailto, and Section 14 ("Contact") mailto/address at the bottom of the page.

## Deliberately left alone

- `AGENTS.md`'s `VIBEBROWSER_REMOTE_URL` example — a real VibeBrowser relay WebSocket URL, unrelated product surface, not a support/contact address.
- `context.md`, `HANDOFF.md`, `.autopilot/state.md` — historical planning/handoff notes documenting the prior decision to move the privacy policy off `opencode.vibebrowser.app/privacy` to GitHub Pages / `opencode.agentlabs.cc`. These are logs of past decisions, not live support/contact surfaces, so rewriting them would misrepresent project history.

## Checks run

- `npx tsc --noEmit` on `website/` — clean, no errors.
- `next lint` / `npx eslint` — could not run: Next.js 16 removed the `next lint` command from its CLI, and the repo has no `eslint.config.js` (ESLint v9+ format). This is a **pre-existing** gap in the website's tooling, unrelated to this change — flagging it separately rather than fixing it here since it's out of scope for a copy fix.
- Full `next build` not run (privacy page reads a file via a relative path outside `website/` that depends on monorepo layout); the change itself is a straight string substitution with no logic touched, and typecheck already passed clean.

## ⚠️ Residual note — please verify manually before closing this out

**Deliverability of `support@agentlabs.cc` was NOT verified from code.** MX records for `agentlabs.cc` exist, but whether there's an active Cloudflare Email Routing rule forwarding `support@agentlabs.cc` to a monitored mailbox could not be confirmed from this repo/PR. A human needs to check the Cloudflare dashboard (Email → Email Routing) to confirm the routing rule is live and points to a mailbox someone actually reads. **Do not assume this is done just because the code now says the right address.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)