### PR TITLE
fix(android): reconcile committed versionCode/versionName with app.json for F-Droid

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,8 +94,8 @@ android {
         applicationId 'cc.agentlabs.opencode'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 32
-        versionName "0.4.5"
+        versionCode 34
+        versionName "0.4.7"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }


### PR DESCRIPTION
## Summary

PART 2 of #86 — this fixes only the stale committed Android version fields.

`android/app/build.gradle` hardcoded `versionCode 32` / `versionName "0.4.5"`, while `app.json` (`expo.android.versionCode`, `expo.version`) had already moved on to `34` / `"0.4.7"`. CI and Play Store builds run `expo prebuild`, which regenerates `build.gradle` from `app.json` and overwrites these literals — so those pipelines were never affected by the stale values.

F-Droid is different: its recipe builds directly from the committed `android/` directory with no `expo prebuild` step, so it read the stale `versionCode 32` / `versionName "0.4.5"` verbatim. That's the root cause of the reused-versionCode bug on F-Droid.

## Change

Bumped the two literals in `android/app/build.gradle` to match `app.json` exactly:
- `versionCode 32` → `versionCode 34`
- `versionName "0.4.5"` → `versionName "0.4.7"`

No other changes. Diff is exactly these two lines.

## Not in scope

PART 1 of #86 (reproducible-build parity between the release workflow and F-Droid's build) is tracked separately and intentionally untouched here.

Refs #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)