### PR TITLE
test(demo): full-text regex matches so the demo E2E flow passes

### DIFF
--- a/.maestro/flows/demo.yaml
+++ b/.maestro/flows/demo.yaml
@@ -58,7 +58,12 @@ name: Demo mode - offline scripted walkthrough (no server, zero-server activatio
 - takeScreenshot: demo-S3_conversation
 
 # Tool call card is collapsed by default (same behavior as a real session) —
-# expand it to reveal the diff.
+# tapping it expands the card, which renders the diff DOWNWARD below the
+# header. Because the card is scrolled to near the bottom of the viewport to
+# tap it, the expanded diff opens off-screen — so scroll again to bring the
+# diff into view before asserting (assertVisible does not auto-scroll).
+# Verified from a CI failure screenshot where the demo rendered correctly but
+# diff-view-scroll sat below the fold.
 - scrollUntilVisible:
     element:
       text: ".*Edit src/components/LoginButton.tsx.*"
@@ -66,6 +71,11 @@ name: Demo mode - offline scripted walkthrough (no server, zero-server activatio
     timeout: 10000
 - tapOn:
     text: ".*Edit src/components/LoginButton.tsx.*"
+- scrollUntilVisible:
+    element:
+      id: "diff-view-scroll"
+    direction: DOWN
+    timeout: 10000
 - assertVisible:
     id: "diff-view-scroll"
 - takeScreenshot: demo-S4_diff_view

--- a/.maestro/flows/demo.yaml
+++ b/.maestro/flows/demo.yaml
@@ -90,8 +90,14 @@ name: Demo mode - offline scripted walkthrough (no server, zero-server activatio
 - takeScreenshot: demo-S5_permission_prompt
 - tapOn:
     text: "Allow"
-# Completion message is a full sentence beginning "Tests passed — …", so
-# match it as a substring regex too.
+# Approving swaps the prompt for a completion message that renders below the
+# fold; scroll to it (full sentence begins "Tests passed — …", matched as a
+# substring regex).
+- scrollUntilVisible:
+    element:
+      text: ".*Tests passed.*"
+    direction: DOWN
+    timeout: 10000
 - assertVisible:
     text: ".*Tests passed.*"
 - takeScreenshot: demo-S6_permission_approved

--- a/.maestro/flows/demo.yaml
+++ b/.maestro/flows/demo.yaml
@@ -43,10 +43,14 @@ name: Demo mode - offline scripted walkthrough (no server, zero-server activatio
 - takeScreenshot: demo-S2_demo_screen_opened
 
 # Scripted conversation renders through the real chat components.
+# Maestro `text` matches the element's FULL text as a regex, so a phrase
+# taken from a longer message must be wrapped in `.*…*` (the user message is
+# a full sentence, not the bare phrase). Verified against a CI run where the
+# demo screen rendered correctly but this bare-substring assert failed.
 - assertVisible:
     id: "chat-bubble-user"
 - assertVisible:
-    text: "login button"
+    text: ".*login button.*"
 - assertVisible:
     id: "chat-bubble-assistant"
 - assertVisible:
@@ -57,11 +61,11 @@ name: Demo mode - offline scripted walkthrough (no server, zero-server activatio
 # expand it to reveal the diff.
 - scrollUntilVisible:
     element:
-      text: "Edit src/components/LoginButton.tsx"
+      text: ".*Edit src/components/LoginButton.tsx.*"
     direction: DOWN
     timeout: 10000
 - tapOn:
-    text: "Edit src/components/LoginButton.tsx"
+    text: ".*Edit src/components/LoginButton.tsx.*"
 - assertVisible:
     id: "diff-view-scroll"
 - takeScreenshot: demo-S4_diff_view
@@ -76,8 +80,10 @@ name: Demo mode - offline scripted walkthrough (no server, zero-server activatio
 - takeScreenshot: demo-S5_permission_prompt
 - tapOn:
     text: "Allow"
+# Completion message is a full sentence beginning "Tests passed — …", so
+# match it as a substring regex too.
 - assertVisible:
-    text: "Tests passed"
+    text: ".*Tests passed.*"
 - takeScreenshot: demo-S6_permission_approved
 
 # Closing CTA routes to the REAL connect form, not a dead link.


### PR DESCRIPTION
## What

Fixes the demo Maestro flow (`.maestro/flows/demo.yaml`) added in #108, which was failing in the **non-blocking** newer-flows lane.

## Why it failed (and why the feature is fine)

The demo screen renders correctly — a CI run's `demo-S2` screenshot shows the user message, the assistant's reasoning block, and the tool-call card all present. The flow itself was wrong: it asserted **bare substrings** (`text: "login button"`, `text: "Tests passed"`) against Maestro's `text` matcher, which matches the element's **full** text as a regex. Those phrases live inside longer sentences, so they never matched. The exact i18n labels the flow also checks (`Thinking`, `Permission Required`, `Allow`) matched fine.

## Fix

Wrap the partial phrases in `.*…*` (and the tool-title taps, in case the title truncates in the a11y tree). Flow-only change — no app code touched, the demo feature is unchanged.

Note: still runs in the non-blocking lane; once it's confirmed green here it's a candidate to graduate to a blocking flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6
