### PR TITLE
chore(release): prepare 0.4.8 — ship demo mode + first-run retention fixes

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "OpenCode",
     "slug": "opencode-mobile",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "orientation": "portrait",
     "scheme": "opencode",
     "userInterfaceStyle": "automatic",
@@ -35,7 +35,7 @@
     },
     "android": {
       "package": "cc.agentlabs.opencode",
-      "versionCode": 34,
+      "versionCode": 35,
       "usesCleartextTraffic": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/fastlane/metadata/android/en-US/changelogs/35.txt
+++ b/fastlane/metadata/android/en-US/changelogs/35.txt
@@ -1,0 +1,6 @@
+v0.4.8 — Try it before you connect
+
+- New: tap "Try a demo" on the home screen to see OpenCode in action — chat, tool calls, code diffs, and approvals — without setting up a server first
+- Clearer first-time setup: the home and connect screens now explain that OpenCode needs a computer running `opencode serve` on your network (or via Tailscale), with a link to the setup guide
+- Faster feedback when a server can't be reached — no more long waits on a wrong address
+- Fixed the directory browser occasionally getting stuck on an empty "enter a path" state

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/mobile",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {


### PR DESCRIPTION
## What

Prepares the **0.4.8** release (versionCode 35) so the retention work merged since v0.4.7 actually reaches the 1K+ Play users. It's currently all sitting on `main`, unreleased.

## Included since v0.4.7

- **Offline demo mode (#108)** — installers with no server can now tap "Try a demo" and experience chat / tool calls / diffs / approvals immediately. This is the primary fix for ~0% 7-day retention (diagnosis in `distribution/retention-analysis.md`).
- **First-run clarity + fast-fail timeout (#107)** — home and connect screens explain the `opencode serve` prerequisite; a bad address fails in 12s instead of 30s.
- **Directory-browser stuck-state fix (#106)** — no longer gets stuck on an empty "enter a path" state; plus E2E/CI hardening.

## Changes here

- `package.json` / `app.json`: `0.4.7 → 0.4.8`, `versionCode 34 → 35`
- `fastlane/metadata/android/en-US/changelogs/35.txt`: user-facing notes

## Releasing (owner action)

This PR does **not** publish anything. After merge, cut the release by either tagging `v0.4.8` (triggers `publish-play-store.yml`) or dispatching that workflow with the desired track. Production submission stays a deliberate owner step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6
