### PR TITLE
fix(docs): setup guide install command 404s (opencode -> opencode-ai)

### DIFF
--- a/docs-site/guide/index.html
+++ b/docs-site/guide/index.html
@@ -235,7 +235,7 @@ footer a{margin:0 8px}
       <li id="step-server">
         <h3>Run <code>opencode serve</code> on your machine</h3>
         <p>Install OpenCode if you haven't already, then start it in server mode. Bind it to all interfaces and set a password so only you can connect:</p>
-        <pre><code>npm install -g opencode
+        <pre><code>npm install -g opencode-ai
 
 OPENCODE_SERVER_PASSWORD=yourpassword opencode serve --hostname 0.0.0.0 --port 4096</code></pre>
         <p class="muted">Configure your AI provider key on this machine (for example via OpenCode's auth flow or an environment variable). The key never leaves your server.</p>

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -362,7 +362,7 @@ footer a{margin:0 8px}
       <p><strong>You need your own OpenCode server.</strong> OpenCode Mobile is a client, not a hosted service. Before it is useful you must run an OpenCode server somewhere you control and make it reachable from your phone.</p>
       <ol class="steps" style="margin-bottom:0">
         <li>Install and run OpenCode on your machine:<br>
-          <pre style="margin-top:8px"><code>npm install -g opencode
+          <pre style="margin-top:8px"><code>npm install -g opencode-ai
 OPENCODE_SERVER_PASSWORD=yourpassword opencode serve --hostname 0.0.0.0 --port 4096</code></pre>
         </li>
         <li>Make it reachable from your phone — the simplest secure option is <strong>Tailscale</strong> (connect to your machine's Tailscale IP, e.g. <code>http://100.x.x.x:4096</code>). A Cloudflare Tunnel, ngrok, or the same local network also work.</li>

--- a/docs-site/opencode-on-phone/index.html
+++ b/docs-site/opencode-on-phone/index.html
@@ -228,7 +228,7 @@ footer a{margin:0 8px}
   opencode serve --hostname 0.0.0.0 --port 4096</code></pre>
       <p style="margin-bottom:0" class="muted">
         Setting a password turns on authentication so only you can connect. (Don't have opencode yet?
-        Install it with <code>npm install -g opencode</code>.)
+        Install it with <code>npm install -g opencode-ai</code>.)
       </p>
     </div>
 


### PR DESCRIPTION
## 🔴 Critical funnel bug — verified

The setup guide's **step 1 hard-fails for every user who follows it.**

- `npm install -g opencode` → **npm 404, package does not exist**
- The real package is **`opencode-ai`** (v1.18.3, bin `opencode`) — used everywhere else in the repo (store listings, launch posts, troubleshooting)

This is on the exact page the app's empty state and the new demo-mode CTA link to (`SETUP_GUIDE_URL`), so it directly leaks the activation funnel we've been building: users see value in the demo → go to set up a server → the first command errors → they bounce.

## Fix

Corrected `opencode` → `opencode-ai` on the three docs-site pages that had it wrong:
- `docs-site/guide/index.html` (the linked setup guide)
- `docs-site/index.html` (landing "Install and run" snippet)
- `docs-site/opencode-on-phone/index.html`

Swept the rest of `docs-site/` and `website/` — no other wrong occurrences remain. Verified against the npm registry.

## ⚠️ Deploy required to fix the LIVE site

There's no auto-deploy — the live site is served from `gh-pages` (updated manually), so **merging this does not fix the live guide.** After merge, deploy the corrected `docs-site/` files to `gh-pages` (worktree of `gh-pages` → copy changed files to root → commit → `push HEAD:gh-pages`; do **not** touch the `gh-pages` `fdroid/` directory). I did not deploy — publishing to the public site is an owner action — but this one is worth doing promptly; it's actively costing activations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6
