### PR TITLE
fix(funnel): repair activation-path bugs found in end-to-end audit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ You need a running [opencode](https://github.com/sst/opencode) server to test th
 
 ```bash
 # Install opencode
-npm install -g opencode
+npm install -g opencode-ai
 
 # Start it in server mode on all interfaces
 OPENCODE_SERVER_PASSWORD=devpassword opencode serve --hostname 0.0.0.0 --port 4096

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are **three working ways** to install OpenCode Mobile today, all for Andro
    ```
    https://dzianisv.github.io/opencode-mobile/fdroid/repo
    ```
-   In the F-Droid app: **Settings → Repositories → + (add)** and paste the URL above. Current version: **v0.4.3**.
+   In the F-Droid app: **Settings → Repositories → + (add)** and paste the URL above. Current version: **v0.4.7**.
 
 3. **Direct signed APK** — download the latest release and install it manually:
    **https://github.com/dzianisv/opencode-mobile/releases/latest**
@@ -64,7 +64,7 @@ OpenCode Mobile is a React Native / Expo app that brings the power of the [openc
 
 ## Get OpenCode Mobile
 
-Package: `cc.agentlabs.opencode` · Android only · current version v0.4.3
+Package: `cc.agentlabs.opencode` · Android only · current version v0.4.7
 
 | Channel | Status | How |
 |---|---|---|
@@ -86,7 +86,7 @@ Package: `cc.agentlabs.opencode` · Android only · current version v0.4.3
 
 ```bash
 # Install opencode (if you haven't already)
-npm install -g opencode
+npm install -g opencode-ai
 
 # Run opencode in server mode
 OPENCODE_SERVER_PASSWORD=yourpassword opencode serve --hostname 0.0.0.0 --port 4096
@@ -137,7 +137,7 @@ OpenCode Mobile is a thin client. It speaks the opencode HTTP + SSE API: listing
 
 ## Project Status
 
-**Current version: v0.4.3**
+**Current version: v0.4.7**
 
 | Feature | Status |
 |---|---|

--- a/docs-site/comparison/index.html
+++ b/docs-site/comparison/index.html
@@ -198,7 +198,7 @@ td:first-child{font-weight:500}
           </tr>
           <tr>
             <td>Bring your own LLM</td>
-            <td class="yes">Yes — any provider opencode supports (Claude, GPT-4, local models)</td>
+            <td class="yes">Yes — any provider opencode supports (Claude, GPT, Gemini, local models)</td>
             <td class="no">OpenAI models only</td>
             <td class="no">GitHub Copilot models only</td>
           </tr>

--- a/docs-site/download/index.html
+++ b/docs-site/download/index.html
@@ -42,11 +42,11 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "OpenCode Mobile",
-  "operatingSystem": "Android 8.0+",
+  "operatingSystem": "Android 7.0+",
   "applicationCategory": "DeveloperApplication",
   "description": "Open-source Android client for the OpenCode AI coding agent. Connect to an opencode server you run yourself and code from your phone.",
   "downloadUrl": "https://github.com/dzianisv/opencode-mobile/releases/latest/download/app-release.apk",
-  "softwareVersion": "0.4.3",
+  "softwareVersion": "0.4.7",
   "license": "https://github.com/dzianisv/opencode-mobile/blob/main/LICENSE",
   "author": { "@type": "Organization", "name": "VIBE TECHNOLOGIES, LLC" },
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
@@ -171,7 +171,7 @@ footer a{margin:0 8px}
       OpenCode Mobile is the free, open-source Android client for the
       <a href="https://github.com/sst/opencode">OpenCode</a> AI coding agent. Install it from
       the F-Droid repository for automatic updates, or grab the signed APK directly.
-      No account, no tracking, no ads. Current version <strong>0.4.3</strong>.
+      No account, no tracking, no ads. Current version <strong>0.4.7</strong>.
     </p>
     <div class="note">
       <strong>Before you install:</strong> OpenCode Mobile is a <em>client</em> — it connects to an
@@ -252,7 +252,7 @@ footer a{margin:0 8px}
     </p>
     <h2>What do I need to run it?</h2>
     <p>
-      An Android 8.0+ device, a machine running <code>opencode serve</code>, a way to reach that machine
+      An Android 7.0+ device, a machine running <code>opencode serve</code>, a way to reach that machine
       from your phone (Tailscale, a Cloudflare/ngrok tunnel, or the same local network), and your own AI
       provider key. The <a href="../guide/">setup guide</a> walks through every step in about 15 minutes.
     </p>

--- a/docs-site/features/index.html
+++ b/docs-site/features/index.html
@@ -50,7 +50,7 @@
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "featureList": [
     "Real-time AI coding sessions via Server-Sent Events",
-    "Multi-model support: Claude, GPT-4, Gemini, Ollama, and any opencode-compatible model",
+    "Multi-model support: Claude, GPT, Gemini, Ollama, and any opencode-compatible model",
     "Tailscale and VPN connectivity for private server access",
     "Streaming diff and tool-use output as the agent works",
     "Full session history with scroll and search",
@@ -234,7 +234,7 @@ footer a:hover{color:var(--accent)}
     <h2>System requirements</h2>
     <ul class="check-list">
       <li>Android 7.0 (API 24) or later</li>
-      <li><a href="https://github.com/opencode-ai/opencode">opencode</a> running on a reachable server (<code>opencode serve</code>)</li>
+      <li><a href="https://github.com/sst/opencode">opencode</a> running on a reachable server (<code>opencode serve</code>)</li>
       <li>Network path from phone to server (LAN, Tailscale VPN, or any tunnel)</li>
       <li>~15 MB storage for the app; session history grows with use</li>
     </ul>

--- a/docs-site/vs-termux/index.html
+++ b/docs-site/vs-termux/index.html
@@ -436,9 +436,9 @@ OPENCODE_SERVER_PASSWORD=yourpassword opencode serve --hostname 0.0.0.0 --port 4
       happens:
     </p>
     <ol>
-      <li>The app opens an SSE stream to your opencode server's <code>/session/{id}/events</code> endpoint.</li>
-      <li>You type a prompt — the app posts it to <code>/session/{id}/chat</code>.</li>
-      <li>The server forwards the prompt to your configured LLM (Claude, GPT-4, a local model, whatever you set up).</li>
+      <li>The app opens an SSE stream to your opencode server's <code>/global/event</code> endpoint.</li>
+      <li>You type a prompt — the app posts it to <code>/session/{id}/prompt_async</code>.</li>
+      <li>The server forwards the prompt to your configured LLM (Claude, GPT, a local model, whatever you set up).</li>
       <li>Tokens stream back from the LLM to the server, and from the server over SSE to the app.</li>
       <li>When the agent proposes a file change, the app renders the diff and waits for your approve/reject tap.</li>
       <li>Your approval goes back to the server, which applies the change to the real filesystem.</li>

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -36,13 +36,20 @@ export interface DiagnosticReport {
   timestamp: string
 }
 
-async function timedFetch(name: string, target: string, init?: RequestInit): Promise<ProbeAttempt> {
+// requireOk: whether a non-2xx HTTP response counts as a probe failure.
+// The health probe must actually succeed (2xx) to mean "the server works" —
+// otherwise a 401/403/404/500 response was being reported as ok:true, which
+// made classify() short-circuit to "connection actually works now" even when
+// auth failed or the server errored. The root probe only checks reachability
+// (any HTTP response, even an error status, proves something is listening).
+async function timedFetch(name: string, target: string, init?: RequestInit, opts?: { requireOk?: boolean }): Promise<ProbeAttempt> {
+  const requireOk = opts?.requireOk ?? true
   const start = Date.now()
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
   try {
     const res = await fetch(target, { ...init, signal: controller.signal })
-    return { name, target, ok: true, status: res.status, durationMs: Date.now() - start }
+    return { name, target, ok: requireOk ? res.ok : true, status: res.status, durationMs: Date.now() - start }
   } catch (error: unknown) {
     const err = error as { name?: string; message?: string; cause?: unknown }
     const aborted = err?.name === "AbortError"
@@ -80,7 +87,7 @@ export async function probeConnection(url: string, auth?: { username: string; pa
     const base = `${parsed.scheme}://${parsed.host}:${parsed.port}`
     ;[health, root, internet] = await Promise.all([
       timedFetch("health", `${base}/global/health`, { headers }),
-      timedFetch("server-root", `${base}/`, { headers }),
+      timedFetch("server-root", `${base}/`, { headers }, { requireOk: false }),
       timedFetch("internet", INTERNET_CHECK_URL),
     ])
   } else {


### PR DESCRIPTION
## Why

#113 fixed a docs 404 (`npm install -g opencode` -> `opencode-ai`) in 3 docs-site pages, but the same bug was still live in README.md and CONTRIBUTING.md — proof that a single funnel bug can hide in more than one place. This PR is a systematic end-to-end trace of the activation path (store listing -> docs setup guide -> in-app onboarding -> connect flow -> external links) to find and fix the rest, with no spend.

Traced: README.md, distribution/*, docs-site/* (guide, opencode-on-phone, download, features, comparison, vs-termux, remote-access, ios, claude-code-android, troubleshooting), app/(tabs)/index.tsx, app/demo.tsx, app/connection/add.tsx & [id].tsx, src/lib/sdk.ts, src/lib/diagnostics*.ts, src/lib/waitlist.ts, i18n catalogs, plus live spot-checks of the Play Store listing, GitHub releases, F-Droid repo index, and the GitHub Sponsors link.

## Fixed in this PR

| Severity | Finding | Where | Fix |
|---|---|---|---|
| High | `npm install -g opencode` (404s — real package is `opencode-ai`) still present outside the docs-site pages #113 already fixed | `README.md:89`, `CONTRIBUTING.md:87` | changed to `opencode-ai` |
| High | Health probe reported `ok:true` for *any* resolved HTTP response, including 401/403/404/500. A wrong password or broken server therefore classified as `"Health endpoint responded — connection actually works now."` right next to the real error — the opposite of the actionable-error goal from #79 | `src/lib/diagnostics.ts:44` (`timedFetch`), used at `:82` | health probe now requires a real 2xx (`res.ok`); root-reachability probe explicitly opts out (`requireOk: false`) to keep the reachability-only semantics `diagnostics-classify.test.ts` already assumes |
| Medium | "How it works" explainer described API endpoints that don't exist (`/session/{id}/events`, `/session/{id}/chat`); real endpoints per `src/lib/sdk.ts` are `/global/event` and `/session/{id}/prompt_async` | `docs-site/vs-termux/index.html:439-440` | corrected to the real endpoints |
| Low | opencode repo link pointed at `github.com/opencode-ai/opencode` instead of `github.com/sst/opencode`, the org used everywhere else (10 other places) in the docs | `docs-site/features/index.html:237` | fixed to `sst/opencode` |
| Low | Stale version `v0.4.3` (5 releases behind) shown in 5 places; verified actual latest shipped release is `v0.4.7` via GitHub Releases (`releases/latest` -> tag `v0.4.7`) and the live F-Droid repo index (`versionName: "0.4.7"`) | `README.md:31,67,140`, `docs-site/download/index.html:49,174` | bumped to `v0.4.7` |
| Low | Android min-OS contradiction: `docs-site/features` said "Android 7.0 (API 24)", `docs-site/download` said "Android 8.0+". Verified via the live F-Droid manifest: `minSdkVersion: 24` = Android 7.0 | `docs-site/download/index.html:45,255` | corrected to "Android 7.0+" |
| Low | Stale "GPT-4" model naming (owner already established a model-agnostic policy in #83 for the Play listing, specifically to stop the copy dating itself) | `docs-site/comparison/index.html:201`, `docs-site/features/index.html:53`, `docs-site/vs-termux/index.html:441` | reworded to "Claude, GPT, Gemini, ..." |

**Verification**: `npm test` (181/181 pass) and `npx tsc --noEmit` (0 errors) both clean. Also live-checked: all README/docs-site external links and shields.io badges resolve (200), `SETUP_GUIDE_URL`/`PRIVACY_POLICY_URL` resolve, no orphaned in-page anchors, no missing i18n keys anywhere in `app/`/`src/` (0 of ~any `t()` keys missing from `en.json`/`zh-Hans.json`), no dead/no-op `onPress` handlers in the onboarding path, and the #92/#87 waitlist card already POSTs to a real endpoint (`src/lib/waitlist.ts`) with a mailto fallback only on network/5xx failure — not a stub.

## Found, not fixed (needs a decision or is outside this repo)

| Severity | Finding | Where | Why not fixed here |
|---|---|---|---|
| High | The **live** Google Play Console listing's support contact email is `support@vibebrowser.app` — an unrelated product's domain — instead of `support@agentlabs.cc`. Every source-controlled reference (`fastlane/metadata/`, `distribution/play-listing.md`, `distribution/privacy-policy.*`, etc.) already correctly says `support@agentlabs.cc`; this is a stale Play Console *setting*, not a repo file. A user who hits trouble mid-setup and taps "support" on the store listing reaches a dead/wrong inbox. | Play Console -> Store presence -> Store settings -> Contact details (not in this repo) | Requires human access to Play Console; no file to patch |
| Medium | The live Play Store description still contains the stale "GPT-4" wording that #83 already fixed in the canonical source (`distribution/play-listing.md`) — the updated copy hasn't been pushed to the live listing yet | Play Console (live) vs `distribution/play-listing.md` (already correct) | Requires a human to copy the updated listing into Play Console |
| Medium | Messaging conflict: the Quick-mode "OpenCode Connect — Coming Soon" card (waitlist-only) sits next to Advanced mode's "Cloud" connection type, which lets a user type a URL (placeholder `https://api.opencode.ai`) as if a hosted cloud option works today | `app/connection/add.tsx:343-397` (waitlist card) vs `app/connection/add.tsx:470-478` (Cloud type placeholder) | Unclear whether "Cloud" type is meant as a generic "any public HTTPS server" option (unrelated to the waitlisted managed-hosting feature) or an accidental preview of it — needs a product call, not a mechanical fix |
| Low | `github.com/sponsors/VibeTechnologies` (README "Supporters and Sponsors" CTA) 302-redirects to the plain org profile (`github.com/VibeTechnologies`) — GitHub Sponsors isn't actually enabled for the account, so the funding CTA is a dead end | `README.md:166` | Requires enabling GitHub Sponsors for the org (business/human action), or replacing the CTA — not a code fix |
| Low | `app/connection/add.tsx:112,187` and `app/connection/[id].tsx:111` still append the raw, untranslated `error.message` string alongside the friendly classified summary in the "Connection Failed" alert | same files | Functional now that the underlying misclassification bug (fixed above) is gone; whether to keep/trim the raw technical detail for power users is a UX call |

## Funnel steps confirmed clean

- Store/README entry: all links, badges, and package name now correct
- In-app onboarding (`app/(tabs)/index.tsx`, `app/demo.tsx`): every CTA wired to a real route, no dead buttons
- Waitlist card (#92/#87): already a real POST with mailto fallback, not a stub
- i18n: zero missing translation keys anywhere in the onboarding path (or the app)
- Connect flow placeholders/help text/ports match `README.md` and `src/lib/sdk.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
