### PR TITLE
fix: notifications never requested + wrong-session-on-back-nav + 3 more

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -30,6 +30,7 @@ function RootLayout() {
   const { initialize: initAuth, isLoading: authLoading } = useAuth()
   const { loadConnections, isLoading: connectionsLoading, client } = useConnections()
   const sseStarted = useRef(false)
+  const notifPermissionRequested = useRef(false)
 
   // Telemetry consent state: null = loading, 'unknown' = show modal, else decided
   const [consentState, setConsentState] = useState<"loading" | "unknown" | "decided">("loading")
@@ -42,9 +43,12 @@ function RootLayout() {
     // Connect notification preferences to the notification module
     notifications.configure(() => useSettings.getState().notifications)
 
-    // Navigate to session when user taps a notification
+    // Navigate to session when user taps a notification. Connection-drop
+    // notifications carry no sessionId (they aren't about a session) — route
+    // to the home tab instead of "/session/" (an empty, dead-end route).
     const unsubNotifications = notifications.onTap((data) => {
-      router.push(`/session/${data.sessionId}`)
+      if (data.sessionId) router.push(`/session/${data.sessionId}`)
+      else router.push("/")
     })
 
     // Load telemetry consent — initialise Sentry only if previously granted
@@ -79,6 +83,18 @@ function RootLayout() {
       sseStarted.current = true
       useEvents.getState().connect()
       useCatalog.getState().load()
+      // Request OS notification permission once we have a live connection —
+      // the in-context moment the user will start running agent tasks they'll
+      // want to be pinged about. Previously this was only ever requested when
+      // a user manually toggled a notification switch off→on in Settings; since
+      // most categories default on, that path never fired for typical users
+      // and send() silently no-op'd on every notification (permission stayed
+      // "undetermined"). setup() is idempotent — it won't re-prompt once the
+      // OS has a decision — so the ref just avoids redundant calls per session.
+      if (!notifPermissionRequested.current) {
+        notifPermissionRequested.current = true
+        void notifications.setup()
+      }
     } else if (!client && sseStarted.current) {
       sseStarted.current = false
       useEvents.getState().disconnect()

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -12,7 +12,7 @@ import {
   ActivityIndicator,
   Alert,
 } from "react-native"
-import { useLocalSearchParams, Stack, useRouter } from "expo-router"
+import { useLocalSearchParams, Stack, useRouter, useFocusEffect } from "expo-router"
 import { Ionicons } from "@expo/vector-icons"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useTranslation } from "react-i18next"
@@ -247,16 +247,25 @@ export default function SessionScreen() {
     flatListRef.current?.scrollToOffset({ offset: 0, animated })
   }, [])
 
-  useEffect(() => {
-    if (!id) return
-    selectSession(id, directory).then(() => {
-      // Re-fetch pending permissions/questions from the server to recover from
-      // missed SSE events or failed optimistic removals
-      const connState = useConnections.getState()
-      const c = directory ? (connState.clientForDirectory(directory) ?? connState.client) : connState.client
-      if (c) refreshPending(c, id)
-    })
-  }, [id, directory])
+  // Re-select on every focus, not just mount. currentSession/messages/
+  // permissions are a single global store, and the native stack keeps screens
+  // underneath a pushed one mounted. Without re-selecting on focus, navigating
+  // to another session and back would leave this screen bound to the *other*
+  // session's data (and its permission/question prompts) — so a user could
+  // approve the wrong session's tool call. useFocusEffect re-binds this screen
+  // to its own session whenever it becomes visible again.
+  useFocusEffect(
+    useCallback(() => {
+      if (!id) return
+      selectSession(id, directory).then(() => {
+        // Re-fetch pending permissions/questions from the server to recover from
+        // missed SSE events or failed optimistic removals
+        const connState = useConnections.getState()
+        const c = directory ? (connState.clientForDirectory(directory) ?? connState.client) : connState.client
+        if (c) refreshPending(c, id)
+      })
+    }, [id, directory]),
+  )
 
   // Sync model chip from latest assistant message
   useEffect(() => {

--- a/src/components/chat/QuestionPrompt.tsx
+++ b/src/components/chat/QuestionPrompt.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { View, Text, TextInput, TouchableOpacity, StyleSheet } from "react-native"
 import { Ionicons } from "@expo/vector-icons"
 import { useTranslation } from "react-i18next"
@@ -33,6 +33,22 @@ export function QuestionPrompt({ request, isDark, onReply, onReject }: Props) {
   const [showCustom, setShowCustom] = useState(false)
   const [current, setCurrent] = useState(0)
 
+  // A question is answered exactly once. Without this guard, a double-tap on a
+  // single-select option schedules two `onReply` timers; the second reply hits
+  // an already-resolved request server-side and surfaces a spurious
+  // "Reply failed" alert even though the answer went through.
+  const replied = useRef(false)
+  const reply = (a: string[][]) => {
+    if (replied.current) return
+    replied.current = true
+    onReply(a)
+  }
+  const reject = () => {
+    if (replied.current) return
+    replied.current = true
+    onReject()
+  }
+
   const q = request.questions[current]
   if (!q) return null
 
@@ -45,7 +61,7 @@ export function QuestionPrompt({ request, isDark, onReply, onReject }: Props) {
       } else {
         copy[current] = [label]
         if (request.questions.length === 1) {
-          setTimeout(() => onReply(copy), 100)
+          setTimeout(() => reply(copy), 100)
         }
       }
       return copy
@@ -60,7 +76,7 @@ export function QuestionPrompt({ request, isDark, onReply, onReject }: Props) {
     setCustom("")
     setShowCustom(false)
     if (request.questions.length === 1) {
-      onReply(copy)
+      reply(copy)
     }
   }
 
@@ -116,7 +132,7 @@ export function QuestionPrompt({ request, isDark, onReply, onReject }: Props) {
       </View>
 
       <View style={s.footer}>
-        <TouchableOpacity onPress={onReject}>
+        <TouchableOpacity onPress={reject}>
           <Text style={[s.dismiss, isDark && s.metaDark]}>{t("chat.questionPrompt.dismiss")}</Text>
         </TouchableOpacity>
         {(request.questions.length > 1 || q.multiple) && (
@@ -126,7 +142,7 @@ export function QuestionPrompt({ request, isDark, onReply, onReject }: Props) {
               if (current < request.questions.length - 1) {
                 setCurrent(current + 1)
               } else {
-                onReply(answers)
+                reply(answers)
               }
             }}
           >

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -206,13 +206,21 @@ export const useEvents = create<EventsState>((set, get) => ({
                 // as a received response or a review-worthy success.
                 const aborted = abortedSessions.has(sessionID)
                 if (!aborted) track(AnalyticsEvent.ResponseReceived)
-                const match = useSessions.getState().sessions.find((s) => s.id === sessionID)
-                notify({
-                  category: "completed",
-                  title: "Task completed",
-                  body: sanitizeBody(match?.title, "Session finished processing"),
-                  sessionId: sessionID,
-                })
+                // Only notify "Task completed" for a genuine completion — a
+                // user-cancelled run didn't complete, and an errored run
+                // already fired its own "Session error" notification (session.error
+                // doesn't touch sessionStatus, so an errored session still lands
+                // here via busy→idle). Without this guard the user gets a
+                // misleading — or duplicate, contradictory — completion push.
+                if (!aborted && !erroredSessions.has(sessionID)) {
+                  const match = useSessions.getState().sessions.find((s) => s.id === sessionID)
+                  notify({
+                    category: "completed",
+                    title: "Task completed",
+                    body: sanitizeBody(match?.title, "Session finished processing"),
+                    sessionId: sessionID,
+                  })
+                }
                 // Genuinely positive moment — count it toward the one-time
                 // store review prompt, but only if this run never errored
                 // (session.error doesn't touch sessionStatus, so an errored


### PR DESCRIPTION
Five verified correctness bugs from an adversarial review of the notification and permission/approval paths (two other reported findings were checked and refuted/deemed intentional — see commit).

## High impact
1. **Notifications never worked for most users.** OS permission was requested *only* from the Settings toggle's off→on branch — but every category except `completed` defaults on, so a normal user never triggered it, permission stayed `undetermined`, and `send()` silently no-op'd every notification. Now requested once on first live connection (in-context). This is the core reason 'your agent needs input / finished' pushes weren't reaching users → a real re-engagement/retention loss.
2. **Wrong session after back-navigation.** `currentSession`/`permissions` are a global store and the screen only resynced on mount; the native stack keeps a screen mounted under a pushed one, so navigating to another session and back could leave the screen bound to the *other* session's data and prompts — a user could **approve the wrong session's tool call**. Fixed with `useFocusEffect` resync.

## Medium / low
3. 'Task completed' fired on aborted/errored runs (misleading; duplicate push alongside 'Session error'). Gated by `!aborted && !errored`.
4. Tapping a connection-drop notification (no sessionId) went to an empty `/session/` dead-end → route home.
5. Double-tap on a single-select question sent two replies → spurious 'Reply failed' alert. One-shot guard.

## Not changed (verified)
- `completed` default-off — defensible anti-spam (the app still notifies when the agent *needs* input). Left as-is.

typecheck clean, 187/187 tests. E2E exercises the connect/session/permission path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6