### PR TITLE
chore(release): prepare 0.4.9 — bundle core + notification fixes

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "OpenCode",
     "slug": "opencode-mobile",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "orientation": "portrait",
     "scheme": "opencode",
     "userInterfaceStyle": "automatic",
@@ -35,7 +35,7 @@
     },
     "android": {
       "package": "cc.agentlabs.opencode",
-      "versionCode": 35,
+      "versionCode": 36,
       "usesCleartextTraffic": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/fastlane/metadata/android/en-US/changelogs/36.txt
+++ b/fastlane/metadata/android/en-US/changelogs/36.txt
@@ -1,0 +1,8 @@
+v0.4.9 — smoother, more reliable, easier to start
+
+- New: "Try a demo" on the home screen — see OpenCode in action (chat, tool calls, diffs, approvals) without setting up a server first
+- Clearer first-time setup: the app now explains it needs a computer running `opencode serve` (on your network or via Tailscale) and links to a setup guide
+- More reliable notifications: you're now correctly asked for notification permission, and "task completed" pushes no longer fire for cancelled or failed runs
+- Fixed messages occasionally disappearing when you sent a second one quickly
+- Fixed the session view sometimes showing another session's messages after navigating back
+- Faster feedback when a server can't be reached, and a fix for the directory browser getting stuck

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/mobile",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {


### PR DESCRIPTION
Cuts **0.4.9** (versionCode 36), superseding the un-promoted v0.4.8 with everything merged since:

- Offline demo mode + first-run clarity + fast-fail connect (0.4.8 / #107 #108)
- Core session fixes (#120): queued-message ghosting, selectSession race
- Notification + permission fixes (#121): permission now actually requested, wrong-session-on-back-nav, misleading 'completed' pushes, question double-reply

Production is on **0.4.5**, so promoting v0.4.9 gets users the complete hardened app in one promotion. After merge I'll tag `v0.4.9` (→ internal build); promote versionCode 36 to production via Play Console (add-from-library) to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6