### PR TITLE
Closes #123

### DIFF
--- a/src/lib/session-status-reconcile.test.ts
+++ b/src/lib/session-status-reconcile.test.ts
@@ -1,0 +1,57 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { isSessionActuallyIdle } from "./session-status-reconcile.ts"
+import type { Message } from "./sdk.ts"
+
+const userMsg = (id: string, overrides: Partial<Message> = {}): Message => ({
+  id,
+  sessionID: "s1",
+  role: "user",
+  time: { created: 1 },
+  ...overrides,
+})
+
+const assistantMsg = (id: string, overrides: Partial<Message> = {}): Message => ({
+  id,
+  sessionID: "s1",
+  role: "assistant",
+  time: { created: 1 },
+  ...overrides,
+})
+
+test("no messages -> still busy (nothing to reconcile from)", () => {
+  assert.equal(isSessionActuallyIdle(undefined), false)
+  assert.equal(isSessionActuallyIdle(null), false)
+  assert.equal(isSessionActuallyIdle([]), false)
+})
+
+test("last message is a completed assistant reply -> idle (the missed-event case)", () => {
+  const messages = [userMsg("u1"), assistantMsg("a1", { time: { created: 1, completed: 5 } })]
+  assert.equal(isSessionActuallyIdle(messages), true)
+})
+
+test("last message is an assistant reply that errored out -> idle", () => {
+  const messages = [userMsg("u1"), assistantMsg("a1", { error: { message: "boom" } })]
+  assert.equal(isSessionActuallyIdle(messages), true)
+})
+
+test("last message is a user prompt awaiting a reply -> still busy", () => {
+  const messages = [assistantMsg("a1", { time: { created: 1, completed: 5 } }), userMsg("u2")]
+  assert.equal(isSessionActuallyIdle(messages), false)
+})
+
+test("last message is an assistant reply still streaming (no completed, no error) -> still busy", () => {
+  const messages = [userMsg("u1"), assistantMsg("a1")]
+  assert.equal(isSessionActuallyIdle(messages), false)
+})
+
+test("a follow-up user prompt after a completed assistant reply -> still busy again", () => {
+  // Server queued a second turn: the previous reply completed, but a new user
+  // message was appended after it, so the run may be in progress again.
+  const messages = [
+    userMsg("u1"),
+    assistantMsg("a1", { time: { created: 1, completed: 5 } }),
+    userMsg("u2"),
+  ]
+  assert.equal(isSessionActuallyIdle(messages), false)
+})

--- a/src/lib/session-status-reconcile.ts
+++ b/src/lib/session-status-reconcile.ts
@@ -1,0 +1,31 @@
+import type { Message } from "./sdk"
+
+/**
+ * Decide whether a session the client believes is "busy" has actually
+ * finished, based on the tail of its message history.
+ *
+ * Why this exists (issue #123): `sessionStatus`/`sending` are SSE-driven —
+ * the server's busy -> idle `session.status` event is the only thing that
+ * normally clears them. If the network drops while a session is busy and
+ * that busy -> idle event fires DURING the outage, it is lost: SSE reconnect
+ * resumes the stream from "now", it does not replay missed events. Without a
+ * resync, the UI shows a stuck 'processing' spinner forever even though the
+ * server finished long ago.
+ *
+ * Heuristic: idle iff the most recent message is an assistant message that
+ * has terminated — either it completed normally (`time.completed` set) or it
+ * ended in error (`error` set; the server still finalizes the message on
+ * error, it just never gets a successful `time.completed`). Anything else —
+ * the last message is a user prompt still awaiting a reply, or an assistant
+ * message that hasn't finished streaming — means the run may still be in
+ * progress server-side. Callers MUST treat that as "still busy" and leave the
+ * local state alone: this heuristic only ever clears a stale busy flag, it
+ * never forces a session busy that the server hasn't reported as such, so a
+ * genuinely still-busy session is never clobbered.
+ */
+export function isSessionActuallyIdle(messages: Message[] | null | undefined): boolean {
+  if (!messages || messages.length === 0) return false
+  const last = messages[messages.length - 1]
+  if (last.role !== "assistant") return false
+  return Boolean(last.time?.completed) || Boolean(last.error)
+}

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -8,6 +8,7 @@ import { addBreadcrumb } from "../lib/sentry"
 import { AnalyticsEvent, track } from "../lib/analytics"
 import { recordSuccessfulSession } from "../lib/store-review"
 import { isAuthError } from "../lib/api-error"
+import { isSessionActuallyIdle } from "../lib/session-status-reconcile"
 import type { Client, Part, Session, Message } from "../lib/sdk"
 
 // Session status from the server
@@ -88,6 +89,62 @@ export async function refreshPending(client: Client, sessionID: string) {
   }
 }
 
+// Re-sync any session currently marked "busy" against the server after an
+// SSE reconnect. sessionStatus/sending are SSE-driven and there is normally
+// no other path to idle — if the server's busy -> idle `session.status`
+// event fired while the network was down, SSE reconnect resumes the stream
+// from "now" (it does not replay missed events), so without this the busy
+// flag would never clear and the UI would show a stuck 'processing' spinner
+// forever (issue #123).
+//
+// Only ever CLEARS a busy flag the server confirms is stale via
+// isSessionActuallyIdle — it never marks a session busy, so it can't
+// clobber a genuinely still-busy session. Also re-checks sessionStatus right
+// before writing, so a real session.status event that lands while the fetch
+// is in flight (e.g. the session went busy again) wins over this resync.
+async function resyncBusySessions() {
+  const busySessionIDs = Object.entries(useEvents.getState().sessionStatus)
+    .filter(([, status]) => status.type === "busy")
+    .map(([sessionID]) => sessionID)
+  if (busySessionIDs.length === 0) return
+
+  await Promise.all(
+    busySessionIDs.map(async (sessionID) => {
+      try {
+        const sessionsState = useSessions.getState()
+        const session =
+          sessionsState.sessions.find((s) => s.id === sessionID) ??
+          (sessionsState.currentSession?.id === sessionID ? sessionsState.currentSession : undefined)
+        const connState = useConnections.getState()
+        const client = session?.directory
+          ? connState.clientForDirectory(session.directory) ?? connState.client
+          : connState.client
+        if (!client) return
+
+        const response = await client.session.messages(sessionID)
+        const messages = (response || []).map((m) => m.info)
+        if (!isSessionActuallyIdle(messages)) return // server says still busy - leave it alone
+
+        // A fresh session.status event may have landed on the SSE stream
+        // while this fetch was in flight — that's authoritative, don't
+        // stomp on it.
+        if (useEvents.getState().sessionStatus[sessionID]?.type !== "busy") return
+
+        useEvents.setState((state) => ({
+          sessionStatus: { ...state.sessionStatus, [sessionID]: { type: "idle" } },
+          statusText: { ...state.statusText, [sessionID]: "" },
+        }))
+        useSessions.setState((state) => ({ sending: { ...state.sending, [sessionID]: false } }))
+        if (useSessions.getState().currentSession?.id === sessionID) {
+          useSessions.getState().refreshMessages()
+        }
+      } catch (err) {
+        console.warn("[Events] Failed to resync session status for", sessionID, err)
+      }
+    }),
+  )
+}
+
 export const useEvents = create<EventsState>((set, get) => ({
   connected: false,
   authError: false,
@@ -118,6 +175,12 @@ export const useEvents = create<EventsState>((set, get) => ({
     // Run in background
     ;(async () => {
       let reconnectScheduled = false
+      // True if this connect() call is resuming after a prior disconnect —
+      // gates the one-time busy-session resync below so a cold app start
+      // (sessionStatus is always empty then) never triggers it, and a run of
+      // failed retries can't re-arm the check on every attempt.
+      const isReconnect = get().reconnectAttempts > 0
+      let resyncedAfterReconnect = false
       const stableTimer = setTimeout(() => {
         if (!currentController.signal.aborted) {
           set({ reconnectAttempts: 0, lastDisconnectAt: null })
@@ -162,6 +225,14 @@ export const useEvents = create<EventsState>((set, get) => ({
       try {
         for await (const event of client.global.events(currentController.signal)) {
           if (currentController.signal.aborted) break
+
+          // The stream is genuinely live again (we're actually receiving
+          // data, not just optimistically marked "connected") — resync once
+          // per reconnect, not on every event.
+          if (isReconnect && !resyncedAfterReconnect) {
+            resyncedAfterReconnect = true
+            void resyncBusySessions()
+          }
 
           const payload = (event as any).payload || event
           const type = payload.type as string


### PR DESCRIPTION
## Root cause

`sessionStatus`/`sending` are SSE-driven — the server's busy → idle `session.status` event is the only thing that normally clears them (`src/stores/sessions.ts:132`: "SSE sessionStatus is the source of truth", not recoverable from `session.get()`).

If the network drops while a session is busy and that busy → idle event fires **during** the outage, it's lost: SSE reconnect (`connect()` in `src/stores/events.ts`) resumes the stream from "now" — it does not replay missed events. Nothing else re-syncs the status, so the session shows a stuck 'processing' spinner forever, even though the server finished long ago.

This is the same class of bug #121 fixed for **focus** (re-select session + `refreshPending` on `useFocusEffect`, since the native stack keeps screens mounted underneath a pushed one) — but #121 only covers leaving and re-entering the session. Staying on the screen through a reconnect was still unhandled.

## Fix

- `src/lib/session-status-reconcile.ts` (new, pure, no RN imports): `isSessionActuallyIdle(messages)` — given a session's message history, returns true only if the last message is a terminated assistant reply (`time.completed` set, or it carries a terminal `error`). A trailing user message awaiting a reply, or an assistant message still streaming, reports `false`.

- `src/stores/events.ts`:
  - `resyncBusySessions()` — for every `sessionID` currently marked `"busy"` in `sessionStatus`, fetches `client.session.messages(sessionID)` and calls `isSessionActuallyIdle`. Only if the server confirms idle does it flip `sessionStatus`/`sending` to idle and refresh messages (mirrors the existing busy→idle handling in the real `session.status` event case).
  - Wired into `connect()`: captures `isReconnect = get().reconnectAttempts > 0` before the retry loop starts, then on the **first event actually received** on the new stream (proof the connection is genuinely live, not just optimistically marked `connected: true`), fires `resyncBusySessions()` exactly once per reconnect cycle.

## Avoiding the failure modes called out in the issue

- **Won't clobber a still-busy session**: `isSessionActuallyIdle` only ever returns `true` when the server's own message history shows a terminated run. It never marks anything busy — only clears a stale busy flag the server confirms is gone. There's also a second check immediately before writing: if a real `session.status` event landed on the SSE stream while the resync fetch was in flight, that authoritative event wins and the resync is a no-op.
- **No loop / no excessive refetch**: gated by `isReconnect` (never fires on cold app start, where `sessionStatus` is always empty anyway) and a `resyncedAfterReconnect` flag scoped to that connection's closure — fires once per successful reconnect, not once per event or per retry attempt.
- **Doesn't touch #79's 401/403 auth-stop path**: `isReconnect`/resync only run inside the normal event-processing loop after a stream is established; the auth-error branch (`isAuthError(err)`) is untouched and still stops the reconnect loop the same way.

## Testing

- `src/lib/session-status-reconcile.test.ts` (new, `node --test`): covers no-messages, completed-assistant-reply → idle, errored-assistant-reply → idle, trailing-user-message → still busy, still-streaming-assistant-reply → still busy, and a completed-reply-followed-by-a-new-user-message → still busy again.
- `npm test`: 193/193 passing.
- `npx tsc --noEmit`: clean.

No device/network-drop test was run (none available in this environment) — the reconciliation logic itself is unit-tested and dependency-injected (pure function over `Message[]`), and the reconnect wiring reuses the existing `connect()`/reconnect machinery without altering its control flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)