### PR TITLE
fix(security): re-lock biometric on background + persist edited password

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { Stack, router } from "expo-router"
 import { StatusBar } from "expo-status-bar"
-import { useColorScheme, View, ActivityIndicator } from "react-native"
+import { useColorScheme, View, ActivityIndicator, AppState } from "react-native"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet"
@@ -75,6 +75,24 @@ function RootLayout() {
       })
 
     return unsubNotifications
+  }, [])
+
+  // Re-arm the biometric app-lock when the app leaves the foreground. Without
+  // this, "Require Biometric to Open" is bypassable: authenticate() sets
+  // isAuthenticated=true once at cold start and nothing ever resets it, so the
+  // app stays unlocked for the whole JS-process lifetime — anyone with brief
+  // physical access can reopen a backgrounded app straight into session
+  // history and connection details. lock() flips isAuthenticated back to false
+  // so AuthGate shows the lock screen (and re-prompts) on next foreground.
+  // Fire on "background" only (not the transient "inactive" that the biometric
+  // prompt / app switcher / control center produce) to avoid spurious re-locks.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next) => {
+      if (next === "background" && useAuth.getState().settings.requireBiometric) {
+        useAuth.getState().lock()
+      }
+    })
+    return () => sub.remove()
   }, [])
 
   // Connect/disconnect SSE and load catalog when client changes

--- a/app/connection/[id].tsx
+++ b/app/connection/[id].tsx
@@ -136,13 +136,19 @@ export default function EditConnectionScreen() {
     }
 
     setIsSaving(true)
-    await updateConnection(connection.id, {
-      name: name.trim(),
-      type,
-      url: url.trim(),
-      directory: directory.trim() || undefined,
-      username: username.trim() || undefined,
-    })
+    await updateConnection(
+      connection.id,
+      {
+        name: name.trim(),
+        type,
+        url: url.trim(),
+        directory: directory.trim() || undefined,
+        username: username.trim() || undefined,
+      },
+      // Empty = keep existing password (the field loads blank); a typed value
+      // rotates it in SecureStore.
+      password || undefined,
+    )
     // If this was the active connection, the SSE loop may have stopped
     // retrying after a prior 401 (see events.ts) — reconnect now with the
     // freshly saved credentials instead of leaving the user stuck until

--- a/src/stores/connections.ts
+++ b/src/stores/connections.ts
@@ -47,7 +47,7 @@ interface ConnectionsState {
     source: ConnectionTestSource,
     password?: string,
   ) => Promise<{ ok: boolean; error?: string }>
-  updateConnection: (id: string, updates: Partial<ServerConnection>) => Promise<void>
+  updateConnection: (id: string, updates: Partial<ServerConnection>, password?: string) => Promise<void>
   refreshProject: () => Promise<void>
   // Create a one-off client pointing at a specific directory (for cross-project operations).
   // Pass undefined to get a directory-less client that queries the server without project scope.
@@ -275,10 +275,18 @@ export const useConnections = create<ConnectionsState>((set, get) => ({
     }
   },
 
-  updateConnection: async (id, updates) => {
+  updateConnection: async (id, updates, password) => {
     const connections = get().connections.map((c) => (c.id === id ? { ...c, ...updates } : c))
 
     await SecureStore.setItemAsync(CONNECTIONS_KEY, JSON.stringify(connections))
+
+    // Persist a new password only when one was entered. The edit form loads the
+    // password field blank (passwords aren't read back for security), so an
+    // empty value means "keep the existing password", not "clear it". Written
+    // before the active-client rebuild below so the rebuilt client picks it up.
+    if (password) {
+      await SecureStore.setItemAsync(`${PASSWORDS_PREFIX}${id}`, password)
+    }
 
     // If updating active connection, recreate client
     if (get().activeConnection?.id === id) {


### PR DESCRIPTION
From a focused security review of the credential/auth path. The review also **verified the fundamentals are solid** — passwords live only in `expo-secure-store`, and Sentry, PostHog, and the Chatwoot share-report path all scrub secrets/URLs. Two real issues found:

## 1. HIGH — biometric app-lock never re-armed (bypass)
`authenticate()` sets `isAuthenticated=true` once at cold start, and `lock()` was **never called** (no `AppState` listener). So 'Require Biometric to Open' only worked on the very first launch — after one unlock, anyone with brief physical access could reopen a backgrounded app straight into session history and connection details, for the whole JS-process lifetime. Fixed with an `AppState` listener that calls `lock()` on `background` when the toggle is on (`background` only, so the biometric prompt / app-switcher transient `inactive` don't cause spurious re-locks). The separate 'require biometric to send' feature was already correct.

## 2. Editing a connection's password silently did nothing
The Edit screen has a working password field, but `handleSave` never passed it and `updateConnection` never wrote `PASSWORDS_PREFIX` — so rotating a server password kept using the old one with no error. `updateConnection` now takes an optional password and writes it to SecureStore (blank = keep existing, since the field loads empty for security).

typecheck clean, 187/187 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6