### PR TITLE
chore(release): 0.4.10 (versionCode 37) — reconnect + security fixes

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "OpenCode",
     "slug": "opencode-mobile",
-    "version": "0.4.9",
+    "version": "0.4.10",
     "orientation": "portrait",
     "scheme": "opencode",
     "userInterfaceStyle": "automatic",
@@ -35,7 +35,7 @@
     },
     "android": {
       "package": "cc.agentlabs.opencode",
-      "versionCode": 36,
+      "versionCode": 37,
       "usesCleartextTraffic": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/fastlane/metadata/android/en-US/changelogs/37.txt
+++ b/fastlane/metadata/android/en-US/changelogs/37.txt
@@ -1,0 +1,9 @@
+v0.4.10 — try it instantly, plus reliability & security fixes
+
+- New: "Try a demo" on the home screen — see OpenCode in action (chat, tool calls, diffs, approvals) without setting up a server first
+- Clearer first-time setup: the app explains it needs a computer running `opencode serve` (on your network or via Tailscale) and links to a setup guide
+- Security: "Require Biometric to Open" now re-locks the app every time it goes to the background (previously it stayed unlocked after the first unlock)
+- Fixed: editing a connection's password now actually saves it
+- More reliable notifications, and no false "task completed" pushes for cancelled or failed runs
+- Fixed messages occasionally disappearing when sent quickly, the session view sometimes showing another session, and a stuck "processing" spinner after a network drop
+- Faster feedback when a server can't be reached

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/mobile",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {


### PR DESCRIPTION
Cuts **0.4.10 / versionCode 37** so a **secure, current build** is promotable. v0.4.9 (36) on internal lacks the HIGH biometric-bypass fix (#125) and the reconnect fix (#124); this supersedes it. Promote versionCode 37 to production. After merge I'll tag `v0.4.10` → internal build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6