### PR TITLE
feat(demo): funnel server-less users to the OpenCode Connect waitlist

### DIFF
--- a/app/demo.tsx
+++ b/app/demo.tsx
@@ -86,6 +86,13 @@ export default function DemoScreen() {
               <Text style={s.connectButtonText}>{t("demo.connectButton")}</Text>
             </TouchableOpacity>
             <TouchableOpacity
+              style={s.hostedCtaLink}
+              onPress={handleConnectPress}
+              testID="demo-hosted-cta"
+            >
+              <Text style={s.hostedCtaLinkText}>{t("demo.hostedCtaLink")}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
               style={s.setupGuideLink}
               onPress={() => Linking.openURL(SETUP_GUIDE_URL)}
               testID="demo-setup-guide-link"
@@ -140,6 +147,8 @@ const s = StyleSheet.create({
     alignItems: "center",
   },
   connectButtonText: { color: "#ffffff", fontWeight: "600", fontSize: 15 },
+  hostedCtaLink: { marginTop: 14 },
+  hostedCtaLinkText: { fontSize: 14, fontWeight: "600", color: "#8b5cf6", textAlign: "center" },
   setupGuideLink: { marginTop: 14 },
   setupGuideLinkText: { fontSize: 14, fontWeight: "600", color: "#6366f1" },
 })

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -432,6 +432,7 @@
     "ctaTitle": "Like what you see?",
     "ctaSubtitle": "This was a scripted demo. Connect your own opencode server to do this for real.",
     "connectButton": "Connect your own server",
-    "setupGuideLink": "How to set up a server"
+    "setupGuideLink": "How to set up a server",
+    "hostedCtaLink": "No server? Join the OpenCode Connect waitlist — hosted, no setup"
   }
 }

--- a/src/lib/i18n/zh-Hans.json
+++ b/src/lib/i18n/zh-Hans.json
@@ -432,6 +432,7 @@
     "ctaTitle": "喜欢这个体验吗？",
     "ctaSubtitle": "这是一个脚本化的演示。连接您自己的 opencode 服务器即可真正体验。",
     "connectButton": "连接您自己的服务器",
-    "setupGuideLink": "如何设置服务器"
+    "setupGuideLink": "如何设置服务器",
+    "hostedCtaLink": "没有服务器？加入 OpenCode Connect 候补名单 — 托管，无需搭建"
   }
 }


### PR DESCRIPTION
The demo's only exit was 'Connect your own server' — nothing for the majority who have **no** server (the churn segment). Adds a secondary CTA to the **OpenCode Connect** (hosted, no-setup) waitlist — the monetization funnel per the founder strategy — so the demo converts server-less users into waitlist signups instead of dead-ending them.

Additive: reuses the existing waitlist on `/connection/add` and the demo's `DemoExitedToConnect` tracking. i18n en+zh in parity. typecheck clean, 193/193 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6