### PR TITLE
fix: 6 connection/auth/diagnostics bugs on the first-run path (retention)

### DIFF
--- a/app/connection/[id].tsx
+++ b/app/connection/[id].tsx
@@ -19,6 +19,7 @@ import type { ConnectionType } from "../../src/lib/types"
 import { probeConnection, shareReport } from "../../src/lib/diagnostics"
 import { captureDiagnostic } from "../../src/lib/sentry"
 import { parseUrl } from "../../src/lib/diagnostics-classify"
+import { buildAuth } from "../../src/lib/auth"
 
 // labelKey (not literal text): this is a module-level constant evaluated
 // before i18next is guaranteed ready, so the label is resolved with t() at
@@ -101,10 +102,7 @@ export default function EditConnectionScreen() {
     }
 
     // Failed: run active diagnostics, capture to Sentry, offer a shareable report.
-    const report = await probeConnection(
-      url.trim(),
-      username.trim() && password ? { username: username.trim(), password } : undefined,
-    )
+    const report = await probeConnection(url.trim(), buildAuth(username, password))
     captureDiagnostic(report)
     setIsTesting(false)
 
@@ -136,28 +134,36 @@ export default function EditConnectionScreen() {
     }
 
     setIsSaving(true)
-    await updateConnection(
-      connection.id,
-      {
-        name: name.trim(),
-        type,
-        url: url.trim(),
-        directory: directory.trim() || undefined,
-        username: username.trim() || undefined,
-      },
-      // Empty = keep existing password (the field loads blank); a typed value
-      // rotates it in SecureStore.
-      password || undefined,
-    )
-    // If this was the active connection, the SSE loop may have stopped
-    // retrying after a prior 401 (see events.ts) — reconnect now with the
-    // freshly saved credentials instead of leaving the user stuck until
-    // they relaunch the app.
-    if (useConnections.getState().activeConnection?.id === connection.id) {
-      useEvents.getState().connect()
+    try {
+      await updateConnection(
+        connection.id,
+        {
+          name: name.trim(),
+          type,
+          url: url.trim(),
+          directory: directory.trim() || undefined,
+          username: username.trim() || undefined,
+        },
+        // Empty = keep existing password (the field loads blank); a typed value
+        // rotates it in SecureStore.
+        password || undefined,
+      )
+      // If this was the active connection, the SSE loop may have stopped
+      // retrying after a prior 401 (see events.ts) — reconnect now with the
+      // freshly saved credentials instead of leaving the user stuck until
+      // they relaunch the app.
+      if (useConnections.getState().activeConnection?.id === connection.id) {
+        useEvents.getState().connect()
+      }
+      setIsSaving(false)
+      router.back()
+    } catch {
+      setIsSaving(false)
+      Alert.alert(
+        t("connection.shared.alerts.saveFailedTitle"),
+        t("connection.shared.alerts.saveFailedMessage"),
+      )
     }
-    setIsSaving(false)
-    router.back()
   }
 
   const handleDelete = () => {

--- a/app/connection/add.tsx
+++ b/app/connection/add.tsx
@@ -19,6 +19,7 @@ import type { ConnectionType } from "../../src/lib/types"
 import { probeConnection, shareReport } from "../../src/lib/diagnostics"
 import { captureDiagnostic } from "../../src/lib/sentry"
 import { parseUrl } from "../../src/lib/diagnostics-classify"
+import { buildAuth } from "../../src/lib/auth"
 import { AnalyticsEvent, track } from "../../src/lib/analytics"
 import { submitWaitlistSignup, buildWaitlistMailtoUrl } from "../../src/lib/waitlist"
 
@@ -75,14 +76,17 @@ export default function AddConnectionScreen() {
     track(AnalyticsEvent.ConnectionFormSubmitted, { mode: "quick" })
     setIsConnecting(true)
 
-    // Test connection first
+    // Test connection first. Quick Connect has no username field, so the
+    // connection is intentionally saved without one — buildAuth() defaults
+    // it to "opencode" wherever auth is built. Sending the `username` state
+    // here would leak a value typed earlier in Advanced mode (issue: Back to
+    // Quick silently overriding the default).
     const result = await testConnection(
       {
         id: "",
         name: name || t("connection.shared.namePlaceholder"),
         type: "local",
         url: serverUrl,
-        username: username.trim() || undefined,
       },
       "onboarding",
       password || undefined,
@@ -90,23 +94,27 @@ export default function AddConnectionScreen() {
 
     if (result.ok) {
       // Save and go back
-      await addConnection(
-        {
-          name: name.trim() || t("connection.shared.namePlaceholder"),
-          type: "local",
-          url: serverUrl,
-          username: username.trim() || undefined,
-        },
-        password || undefined,
-      )
-      setIsConnecting(false)
-      router.back()
+      try {
+        await addConnection(
+          {
+            name: name.trim() || t("connection.shared.namePlaceholder"),
+            type: "local",
+            url: serverUrl,
+          },
+          password || undefined,
+        )
+        setIsConnecting(false)
+        router.back()
+      } catch {
+        setIsConnecting(false)
+        Alert.alert(
+          t("connection.shared.alerts.saveFailedTitle"),
+          t("connection.shared.alerts.saveFailedMessage"),
+        )
+      }
     } else {
       // Failed: run active diagnostics, capture to Sentry, offer a shareable report.
-      const report = await probeConnection(
-        serverUrl,
-        username.trim() && password ? { username: username.trim(), password } : undefined,
-      )
+      const report = await probeConnection(serverUrl, buildAuth(undefined, password))
       captureDiagnostic(report)
       setIsConnecting(false)
       Alert.alert(
@@ -160,28 +168,33 @@ export default function AddConnectionScreen() {
     )
 
     if (result.ok) {
-      await addConnection(
-        {
-          name: name.trim(),
-          type,
-          url: url.trim(),
-          directory: directory.trim() || undefined,
-          username: username.trim() || undefined,
-        },
-        password || undefined,
-      )
-      setIsConnecting(false)
-      router.back()
+      try {
+        await addConnection(
+          {
+            name: name.trim(),
+            type,
+            url: url.trim(),
+            directory: directory.trim() || undefined,
+            username: username.trim() || undefined,
+          },
+          password || undefined,
+        )
+        setIsConnecting(false)
+        router.back()
+      } catch {
+        setIsConnecting(false)
+        Alert.alert(
+          t("connection.shared.alerts.saveFailedTitle"),
+          t("connection.shared.alerts.saveFailedMessage"),
+        )
+      }
       return
     }
 
     // Failed: same "Connection Failed" alert as Quick Connect — run active
     // diagnostics, capture to Sentry, and offer a shareable report instead of
     // silently persisting an unreachable/unauthorized connection.
-    const report = await probeConnection(
-      url.trim(),
-      username.trim() && password ? { username: username.trim(), password } : undefined,
-    )
+    const report = await probeConnection(url.trim(), buildAuth(username, password))
     captureDiagnostic(report)
     setIsConnecting(false)
     Alert.alert(

--- a/src/lib/diagnostics-classify.test.ts
+++ b/src/lib/diagnostics-classify.test.ts
@@ -110,6 +110,19 @@ test("internet up, root unreachable, no timeout -> server-unreachable", () => {
   assert.equal(r.classification, "server-unreachable")
 })
 
+test("root reachable but internet probe down still classifies as health-failed, not no-internet", () => {
+  // Regression: the user's own server responded (proving the path to it
+  // works — e.g. captive portal or no WAN but Tailscale LAN still up), so
+  // this must not be misreported as "no internet".
+  const r = classify(
+    okUrl,
+    probe({ ok: false, error: "HTTP 401", status: 401 }), // health
+    probe({ ok: false }), // internet (down)
+    probe({ ok: true }), // root (reachable)
+  )
+  assert.equal(r.classification, "health-failed")
+})
+
 test("server-unreachable adds MagicDNS hint only for hostnames, not IPs", () => {
   const fail = { internet: probe({ ok: true }), root: probe({ ok: false }) }
   const hostR = classify(parseUrl("http://box.ts.net:8080"), probe({ error: "refused" }), fail.internet, fail.root)

--- a/src/lib/diagnostics-classify.ts
+++ b/src/lib/diagnostics-classify.ts
@@ -62,13 +62,17 @@ export function classify(
   if (isTls) {
     return { classification: "tls-error", summary: "TLS/certificate problem. Try http:// instead of https://, or fix the server certificate." }
   }
+  // The user's own server responded to *something* (even a 401/403/404) —
+  // that proves the path to the server works, so a failed public-internet
+  // probe (captive portal, no WAN but Tailscale LAN still up, etc.) must not
+  // override it and misreport a reachable server as "no internet".
+  if (root.ok) {
+    return { classification: "health-failed", summary: `Server is reachable but /global/health failed (HTTP ${health.status ?? "error"}). Likely wrong path, auth, or an old server version.` }
+  }
   if (!internet.ok) {
     return { classification: "no-internet", summary: "The device has no working internet/network at all (public check also failed). Check Wi-Fi/data and Tailscale (VPN) status." }
   }
   // Internet works, server does not.
-  if (root.ok) {
-    return { classification: "health-failed", summary: `Server is reachable but /global/health failed (HTTP ${health.status ?? "error"}). Likely wrong path, auth, or an old server version.` }
-  }
   if (isTimeout) {
     return { classification: "timeout", summary: "Connection to the server timed out (dropped, not refused). Likely a firewall, wrong port, or Tailscale ACL blocking the device." }
   }

--- a/src/lib/headers.test.ts
+++ b/src/lib/headers.test.ts
@@ -57,3 +57,31 @@ test("empty-string directory is treated as absent (falsy)", () => {
   const h = buildRequestHeaders({ directory: "" })
   assert.equal("x-opencode-directory" in h, false)
 })
+
+// Hermes' `btoa` is Latin1-only and throws a RangeError on non-ASCII input.
+// The auth header must be built with a UTF-8-safe base64 helper so a
+// non-ASCII username/password never throws (which otherwise surfaces as an
+// unhandled rejection and a stuck connect spinner).
+
+test("ASCII credentials produce the exact same header as plain btoa (no behavior change)", () => {
+  const h = buildRequestHeaders({ auth: { username: "alice", password: "s3cret" } })
+  assert.equal(h["Authorization"], `Basic ${btoa("alice:s3cret")}`)
+})
+
+test("non-ASCII username does not throw and round-trips back to the credentials", () => {
+  const auth = { username: "usér", password: "s3cret" }
+  assert.doesNotThrow(() => buildRequestHeaders({ auth }))
+  const h = buildRequestHeaders({ auth })
+  const b64 = h["Authorization"].replace("Basic ", "")
+  const decoded = decodeURIComponent(escape(atob(b64)))
+  assert.equal(decoded, `${auth.username}:${auth.password}`)
+})
+
+test("non-ASCII password does not throw and round-trips back to the credentials", () => {
+  const auth = { username: "admin", password: "pässwörd123" }
+  assert.doesNotThrow(() => buildRequestHeaders({ auth }))
+  const h = buildRequestHeaders({ auth })
+  const b64 = h["Authorization"].replace("Basic ", "")
+  const decoded = decodeURIComponent(escape(atob(b64)))
+  assert.equal(decoded, `${auth.username}:${auth.password}`)
+})

--- a/src/lib/headers.ts
+++ b/src/lib/headers.ts
@@ -9,6 +9,17 @@ export interface HeaderConfig {
   auth?: { username: string; password: string }
 }
 
+// `btoa` is Latin1-only and throws a range error on any character outside
+// the Latin1 byte range (e.g. a non-ASCII username/password). UTF-8-encode
+// first so arbitrary Unicode credentials survive - this is the standard
+// browser idiom for UTF-8-safe base64, and matches RFC 7617 (Basic auth
+// credentials are UTF-8 before being base64-encoded). ASCII input is
+// byte-identical to plain `btoa` since encodeURIComponent/unescape
+// round-trip it unchanged.
+function toBase64Utf8(str: string): string {
+  return btoa(unescape(encodeURIComponent(str)))
+}
+
 export function buildRequestHeaders(config: HeaderConfig): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -25,7 +36,7 @@ export function buildRequestHeaders(config: HeaderConfig): Record<string, string
   }
 
   if (config.auth) {
-    const credentials = btoa(`${config.auth.username}:${config.auth.password}`)
+    const credentials = toBase64Utf8(`${config.auth.username}:${config.auth.password}`)
     headers["Authorization"] = `Basic ${credentials}`
   }
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -146,7 +146,9 @@
         "invalidUrlTitle": "Invalid URL",
         "invalidUrlMessage": "Enter a full URL including http:// or https://, e.g. http://192.168.1.100:4096",
         "connectionFailedTitle": "Connection Failed",
-        "unknownError": "Unknown error"
+        "unknownError": "Unknown error",
+        "saveFailedTitle": "Couldn't Save Connection",
+        "saveFailedMessage": "The connection test succeeded, but saving it failed. Please try again."
       }
     },
     "add": {

--- a/src/lib/i18n/zh-Hans.json
+++ b/src/lib/i18n/zh-Hans.json
@@ -146,7 +146,9 @@
         "invalidUrlTitle": "地址无效",
         "invalidUrlMessage": "请输入包含 http:// 或 https:// 的完整地址，例如 http://192.168.1.100:4096",
         "connectionFailedTitle": "连接失败",
-        "unknownError": "未知错误"
+        "unknownError": "未知错误",
+        "saveFailedTitle": "无法保存连接",
+        "saveFailedMessage": "连接测试成功，但保存失败，请重试。"
       }
     },
     "add": {

--- a/src/lib/sdk.ts
+++ b/src/lib/sdk.ts
@@ -245,6 +245,13 @@ async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutM
 }
 
 export function createClient(config: ClientConfig) {
+  // Normalize once: a trailing slash on baseUrl (e.g. pasted into Advanced
+  // mode or the Edit screen) would otherwise survive into every
+  // `${config.baseUrl}${path}` concatenation below as a double slash, which
+  // every request then fails against (while the diagnostics probe, which
+  // reconstructs a clean URL, reports "works now"). A bare URL with no
+  // trailing slash is untouched.
+  config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") }
   return {
     global: {
       // `timeoutMs` overrides the default REQUEST_TIMEOUT_MS — used by the


### PR DESCRIPTION
Six verified correctness bugs in the connect + failure-diagnosis flow — the exact path where a new user connects or churns. Confirmed against code (and the opencode server's auth middleware); typecheck clean, 197 tests pass.

**High impact**
1. **Non-ASCII credentials broke auth and hung the UI.** `btoa` is Latin1-only and *throws* on any non-ASCII char, so a server with a non-ASCII username/password could never connect, and the throw became an unhandled rejection that spun the Connect button forever. Now UTF-8-safe base64 (RFC 7617). ASCII byte-identical. +3 tests.
2. **Diagnostics misdiagnosed auth failures as "no internet".** It returned `no-internet` before checking whether the user's own server was reachable — so a Tailscale user with a wrong password (LAN reachable, no WAN) was told to check their network instead of their password. Now checks `root.ok` first. +1 test.
3. **Trailing-slash URL failed every request while diagnostics said "works now".** An Advanced/Edit URL with a trailing slash produced `host:4096//global/health` on every call; the probe reconstructed a clean URL and reported success. `createClient` now strips the trailing slash.

**Medium**
4. SecureStore failure after a successful test hung the UI (no try/catch) → now caught + alerted.
5. Diagnostics probe used different credentials than the real request (Quick Connect probed with no auth) → now uses `buildAuth`.
6. A username typed in Advanced mode leaked into Quick Connect, silently overriding the `opencode` default → Quick Connect no longer reads that state.

i18n en+zh in parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T12AhSnQVrSxNnvwfCx2z6