### PR TITLE
fix(release): enforce Android version parity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
+      - name: Check release version metadata
+        run: npm run check:versions
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/publish-fdroid.yml
+++ b/.github/workflows/publish-fdroid.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
+      - name: Check release version metadata
+        run: npm run check:versions
+
       - name: Set Sentry release identifiers
         # sentry.gradle (applied from android/app/build.gradle) defaults the
         # upload's --release/--dist to `${applicationId}@${versionName}+${versionCode}`,

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,8 +94,8 @@ android {
         applicationId 'cc.agentlabs.opencode'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 34
-        versionName "0.4.7"
+        versionCode 37
+        versionName "0.4.10"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ios": "expo run:ios",
     "android": "expo run:android",
     "typecheck": "tsc --noEmit",
+    "check:versions": "node scripts/check-version-parity.mjs",
     "test": "node --test 'src/**/*.test.ts'"
   },
   "dependencies": {

--- a/scripts/check-version-parity.mjs
+++ b/scripts/check-version-parity.mjs
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+
+const app = JSON.parse(await readFile("app.json", "utf8"));
+const pkg = JSON.parse(await readFile("package.json", "utf8"));
+const gradle = await readFile("android/app/build.gradle", "utf8");
+
+const name = gradle.match(/^\s*versionName\s+"([^"]+)"/m)?.[1];
+const code = Number(gradle.match(/^\s*versionCode\s+(\d+)/m)?.[1]);
+const expectedName = app.expo.version;
+const expectedCode = app.expo.android.versionCode;
+
+const errors = [];
+
+if (pkg.version !== expectedName) {
+  errors.push(`package.json version ${pkg.version} != app.json version ${expectedName}`);
+}
+
+if (name !== expectedName) {
+  errors.push(`Gradle versionName ${name ?? "missing"} != app.json version ${expectedName}`);
+}
+
+if (code !== expectedCode) {
+  errors.push(`Gradle versionCode ${Number.isNaN(code) ? "missing" : code} != app.json versionCode ${expectedCode}`);
+}
+
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exitCode = 1;
+} else {
+  console.log(`Version metadata aligned: ${expectedName} (${expectedCode})`);
+}


### PR DESCRIPTION
## Summary
- align committed Android Gradle metadata with v0.4.10 / versionCode 37
- add a deterministic package/app/Gradle version parity check
- run the check before normal CI and self-hosted F-Droid publishing

## Why
The v0.4.10 F-Droid release artifact inherited stale Gradle metadata (0.4.7 / 34), preventing a matching reproducible-build comparison. This guard fails builds before another inconsistent release artifact can be published.

## Verification
- `npm run check:versions`
- `npm run typecheck`
- `npm test` (199 passed)
- `git diff --check`

CUA is not required: no `src/**`, `app/**`, or smoke-test runtime path changed.

Closes the version-parity subtask in #95. The full issue remains blocked until a future matching release and fdroiddata recipe complete binary comparison.