### PR TITLE
chore(release): prepare v0.4.11

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,8 +94,8 @@ android {
         applicationId 'cc.agentlabs.opencode'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 37
-        versionName "0.4.10"
+        versionCode 38
+        versionName "0.4.11"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "OpenCode",
     "slug": "opencode-mobile",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "orientation": "portrait",
     "scheme": "opencode",
     "userInterfaceStyle": "automatic",
@@ -35,7 +35,7 @@
     },
     "android": {
       "package": "cc.agentlabs.opencode",
-      "versionCode": 37,
+      "versionCode": 38,
       "usesCleartextTraffic": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/distribution/changelogs/38.txt
+++ b/distribution/changelogs/38.txt
@@ -1,0 +1,5 @@
+v0.4.11 — Release reliability fix
+
+• Aligns Android version metadata across every build path.
+• Ensures Google Play, direct APK, and F-Droid packages report the same version.
+• No runtime behavior changed.

--- a/distribution/whatsnew/whatsnew-en-US
+++ b/distribution/whatsnew/whatsnew-en-US
@@ -1,3 +1,3 @@
-v0.4.10 — Try it instantly, plus reliability & security fixes
+v0.4.11 — Release reliability fix
 
-New: tap "Try a demo" to see OpenCode in action with no server needed. Clearer setup explaining the app connects to a computer running "opencode serve". Security: "Require Biometric to Open" now re-locks whenever the app is backgrounded, and editing a connection's password now saves. Plus more reliable notifications and fixes for disappearing messages, the session view, and a stuck spinner after a network drop.
+This maintenance release aligns Android version metadata across every build path so Google Play, direct APK, and F-Droid packages report the same version. No runtime behavior changed.

--- a/fastlane/metadata/android/en-US/changelogs/38.txt
+++ b/fastlane/metadata/android/en-US/changelogs/38.txt
@@ -1,0 +1,5 @@
+v0.4.11 — release reliability fix
+
+- Aligns Android version metadata across every build path.
+- Ensures Google Play, direct APK, and F-Droid packages report the same version.
+- No runtime behavior changed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencode-ai/mobile",
-  "version": "0.4.7",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencode-ai/mobile",
-      "version": "0.4.7",
+      "version": "0.4.11",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/mobile",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package, Expo, and Gradle metadata to 0.4.11 / code 38
- add Play and F-Droid maintenance-release notes
- replace the stale-version v0.4.10 artifact path without changing runtime behavior

Closes the release-artifact phase of #95; keep #95 open until the published APK is verified and fdroiddata binary comparison passes.

## Verification
- `npm run check:versions`
- `npm run typecheck`
- `npm test` (199 passing)
- `git diff --check`
- Play notes: 218/500 characters

No `src/**`, `app/**`, or CUA script changes; pre-merge CUA is not required for this metadata-only PR.