### PR TITLE
Closes #147

### DIFF
--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -593,7 +593,19 @@ export default function SessionScreen() {
 
       <KeyboardAvoidingView
         style={[s.container, isDark && s.containerDark]}
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        // Both platforms use "padding" so the composer/toolbar is pushed up
+        // above the keyboard via JS-measured keyboard height.
+        //
+        // Android previously relied on the native android:windowSoftInputMode
+        // (adjustResize, see AndroidManifest.xml) with behavior={undefined}
+        // to let the OS resize the window (see #70/#53). Since adopting
+        // Expo's mandatory edge-to-edge display, Android no longer resizes
+        // the window when the keyboard opens — the system assumes insets are
+        // handled dynamically — so adjustResize became a no-op and the
+        // bottom toolbar + input were left completely hidden behind the
+        // keyboard (#147). "padding" restores avoidance without depending
+        // on native resize.
+        behavior="padding"
         keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
       >
         {/* Session info pulldown */}


### PR DESCRIPTION
## Screen affected

Chat/session screen (`app/session/[id].tsx`) — the agent/model toolbar (agent chip, model chip, reasoning-effort/variant chip) rendered directly above the message composer.

The issue's screenshots (Android, `12:47:54` / `12:47:58`) show the toolbar row and the input box both present with the keyboard closed, then both **completely gone** — hidden behind the on-screen keyboard — the moment the keyboard opens. Nothing is visible above the keyboard except the message list.

## Root cause

`KeyboardAvoidingView` on this screen used:

```tsx
behavior={Platform.OS === "ios" ? "padding" : undefined}
```

On Android this leaves `behavior` as `undefined`, i.e. **no JS-side keyboard avoidance at all**. That was intentional: `android:windowSoftInputMode="adjustResize"` is already set in `AndroidManifest.xml` (confirmed — not `adjustPan`, not unset), and a prior fix (#70, closing #53) removed `behavior="height"` specifically because it fought the native `adjustResize` window-resize and caused a different bug (double-compensation).

That worked at the time, but the app has since moved to a newer Expo SDK with Android's **edge-to-edge display mandatory**. Under edge-to-edge, Android no longer resizes the window when the IME (keyboard) appears — the system assumes the app handles insets dynamically instead — so `adjustResize` silently becomes a no-op. With no native resize *and* no JS-side avoidance (`behavior={undefined}`), the toolbar + composer, which are laid out at the bottom of the screen, stay exactly where they were and end up completely covered by the keyboard. This is a known/documented regression pattern for Expo + edge-to-edge + `adjustResize` (confirmed against Expo's own edge-to-edge guidance and independent write-ups of the same issue).

`AndroidManifest.xml`'s `adjustResize` was left as-is — it's harmless (now inert) rather than actively wrong, and Expo's prebuild regenerates it from defaults on every native build anyway (see `expo prebuild --platform android` in CI), so there was nothing to "fix" there.

## Fix

`app/session/[id].tsx`: use `behavior="padding"` on **both** platforms instead of `undefined` on Android. `KeyboardAvoidingView`'s own JS-measured keyboard height now pushes the toolbar/composer above the keyboard directly, independent of whether the native window resizes. `keyboardVerticalOffset` is unchanged (still `90` on iOS to clear the header, `0` on Android).

No other screen uses this exact bottom-toolbar-over-composer layout pattern tied to the root `KeyboardAvoidingView` (the modal-based `KeyboardAvoidingView` in `app/(tabs)/index.tsx` already used `behavior="height"` and lives inside a native `<Modal>`, a different window context — left untouched).

## How to verify on-device

1. Install on an Android device/emulator (SDK 35+ recommended, to reproduce edge-to-edge).
2. Open any chat session.
3. Tap the message input to bring up the keyboard.
4. Confirm the agent/model/variant toolbar row and the input box (with send/mic/attach buttons) remain fully visible directly above the keyboard — not clipped, not hidden.
5. Dismiss the keyboard and confirm the toolbar/composer settle back to the screen bottom with no layout jump or double-offset.
6. Sanity-check iOS is unaffected (still `padding` + 90pt offset, unchanged behavior).

## Testing done

- `npm install && npx tsc --noEmit` — no errors.
- `npm test` — 212 tests, 209 pass / 3 pre-existing cancellations unrelated to this change, 0 failures.
- No Maestro flow asserts the exact `KeyboardAvoidingView` behavior value, so none needed updating; existing composer-touching flows (`diff-scroll`, `variant-picker`, `all-sessions`, `directory-picker`, `activation-positive`) are unaffected by this prop-only change.
- Could not run an actual Android emulator with an IME in this environment — the fix was verified by tracing the root cause against Expo's documented edge-to-edge + `adjustResize` regression and reasoning through the layout, not by an on-device keyboard test. Manual on-device verification (steps above) is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)