### PR TITLE
Closes #150

### DIFF
--- a/src/lib/session-load-reconcile.test.ts
+++ b/src/lib/session-load-reconcile.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { isColdSessionLoad, isLiveEventForSession } from "./session-load-reconcile.ts"
+
+test("isColdSessionLoad: no session shown yet -> cold (needs the spinner)", () => {
+  assert.equal(isColdSessionLoad(undefined, "s1"), true)
+  assert.equal(isColdSessionLoad(null, "s1"), true)
+})
+
+test("isColdSessionLoad: switching to a different session -> cold", () => {
+  assert.equal(isColdSessionLoad("s1", "s2"), true)
+})
+
+test("isColdSessionLoad: re-selecting the session already on screen -> not cold (background refresh)", () => {
+  assert.equal(isColdSessionLoad("s1", "s1"), false)
+})
+
+test("isLiveEventForSession: matching ids -> true", () => {
+  assert.equal(isLiveEventForSession("s1", "s1"), true)
+})
+
+test("isLiveEventForSession: mismatched ids -> false", () => {
+  assert.equal(isLiveEventForSession("s1", "s2"), false)
+})
+
+test("isLiveEventForSession: missing event session id -> false", () => {
+  assert.equal(isLiveEventForSession(undefined, "s1"), false)
+  assert.equal(isLiveEventForSession(null, "s1"), false)
+})
+
+test("isLiveEventForSession: missing active session id -> false", () => {
+  assert.equal(isLiveEventForSession("s1", undefined), false)
+  assert.equal(isLiveEventForSession("s1", null), false)
+})

--- a/src/lib/session-load-reconcile.ts
+++ b/src/lib/session-load-reconcile.ts
@@ -1,0 +1,44 @@
+/**
+ * Decide whether selecting `targetSessionID` for the session detail screen
+ * is a "cold" load — nothing is shown yet, or we're switching to a
+ * different session, so the blocking spinner is appropriate — or a
+ * background refresh of a session that's already loaded and rendering.
+ *
+ * Why this exists (issue #150): the session detail screen re-runs
+ * `selectSession` on every navigation focus (see #121's useFocusEffect
+ * resync, which re-binds this screen to its session on every re-entry, not
+ * just mount — since the native stack keeps screens mounted underneath a
+ * pushed one). That re-fetch is a good idea (it recovers from missed SSE
+ * events), but unconditionally flipping `isLoading` back to `true` for it
+ * hides the ENTIRE conversation — messages, composer, everything — behind a
+ * spinner for as long as the redundant fetch takes. Meanwhile SSE keeps
+ * delivering `message.updated`/`message.part.updated` events the whole
+ * time — the store keeps them, but the screen can't show them while
+ * `isLoading` is blocking the message list. If that redundant fetch is slow
+ * or stalls (flaky mobile network), the conversation looks permanently stuck
+ * "loading" until the user backs out to the sessions list and re-enters —
+ * which works only because it's a fresh attempt that (usually) doesn't hit
+ * the same stall, not because anything was actually fixed.
+ *
+ * A cold load (no session shown yet, or a genuinely different session) still
+ * needs the spinner — there's nothing to show meanwhile. A refresh of the
+ * session already on screen does not: keep showing what's there (which
+ * live SSE updates keep current) while the refetch runs quietly in the
+ * background.
+ */
+export function isColdSessionLoad(currentSessionID: string | null | undefined, targetSessionID: string): boolean {
+  return currentSessionID !== targetSessionID
+}
+
+/**
+ * Decide whether an incoming SSE event's session matches the session a
+ * screen/store is currently bound to — the shared "is this event for me"
+ * check used to key live updates (messages, parts) to the active session,
+ * instead of e.g. matching on stale or missing ids.
+ */
+export function isLiveEventForSession(
+  eventSessionID: string | null | undefined,
+  activeSessionID: string | null | undefined,
+): boolean {
+  return !!eventSessionID && !!activeSessionID && eventSessionID === activeSessionID
+}

--- a/src/stores/sessions.ts
+++ b/src/stores/sessions.ts
@@ -6,6 +6,7 @@ import { addBreadcrumb } from "../lib/sentry"
 import { AnalyticsEvent, track } from "../lib/analytics"
 import { extractPromptFromParts, type PromptFromParts } from "../lib/prompt-from-parts"
 import { mergeIncomingMessage } from "../lib/message-merge"
+import { isColdSessionLoad, isLiveEventForSession } from "../lib/session-load-reconcile"
 
 // Helper to convert API response to our internal format
 function parseMessages(response: MessageWithParts[]): { messages: Message[]; parts: Record<string, Part[]> } {
@@ -128,10 +129,21 @@ export const useSessions = create<SessionsState>((set, get) => ({
 
     const seq = ++selectSeq
     addBreadcrumb({ category: "session", message: "select", data: { sessionID, hasDirectory: Boolean(directory) } })
+    // Re-selecting the session already shown on screen (e.g. #121's
+    // useFocusEffect resync firing again on re-entry) is a background
+    // refresh, not a cold load: the screen already has this session's
+    // messages, and live SSE updates keep flowing to them the whole time.
+    // Forcing isLoading back to true here would hide the entire
+    // conversation — including anything streaming in live right now —
+    // behind a spinner for as long as this redundant fetch takes, and if it
+    // stalls (flaky network), the screen looks permanently stuck "loading"
+    // until the user backs out and re-enters (issue #150). Only a
+    // genuinely new/different session needs the blocking spinner.
+    const isColdLoad = isColdSessionLoad(get().currentSession?.id, sessionID)
     try {
       // Reset optimistic sending — SSE sessionStatus is the source of truth
       set((state) => ({
-        isLoading: true,
+        isLoading: isColdLoad ? true : state.isLoading,
         error: null,
         hasMore: false,
         loadingMore: false,
@@ -409,9 +421,16 @@ export const useSessions = create<SessionsState>((set, get) => ({
     switch (event.type) {
       case "message.updated": {
         const message = (props.info || props.message) as Message | undefined
-        if (!message || message.sessionID !== currentSession.id) return
+        if (!message || !isLiveEventForSession(message.sessionID, currentSession.id)) return
 
-        set((state) => ({ messages: mergeIncomingMessage(state.messages, message) }))
+        set((state) => ({
+          messages: mergeIncomingMessage(state.messages, message),
+          // A live update for the session on screen is proof it has content
+          // to show — clear any stuck spinner even if the initial (or a
+          // redundant re-focus) GET hasn't resolved yet, or never does
+          // (issue #150). Only ever clears, never sets it back to true.
+          isLoading: false,
+        }))
         break
       }
 
@@ -431,6 +450,9 @@ export const useSessions = create<SessionsState>((set, get) => ({
                 ? messageParts.map((p) => (p.id === part.id ? part : p))
                 : [...messageParts, part],
             },
+            // See message.updated above — a live part update is just as
+            // much proof of life as a message update.
+            isLoading: false,
           }
         })
         break
@@ -453,6 +475,7 @@ export const useSessions = create<SessionsState>((set, get) => ({
         set((state) => ({
           sessions: state.sessions.map((s) => (s.id === session.id ? session : s)),
           currentSession: state.currentSession?.id === session.id ? session : state.currentSession,
+          isLoading: isLiveEventForSession(session.id, state.currentSession?.id) ? false : state.isLoading,
         }))
         break
       }


### PR DESCRIPTION
## Root cause

The session detail screen (`app/session/[id].tsx`) re-runs `selectSession()` on every navigation focus, not just on mount — that's #121's fix, which re-binds the screen to its session on every re-entry because the native stack keeps screens mounted underneath a pushed one.

The bug: `selectSession()` unconditionally set `isLoading: true` at the start of **every** call, including a re-focus of the session already shown on screen. That hides the *entire* conversation — message list and composer — behind a spinner for as long as that (redundant) `GET /session/:id` + `GET /session/:id/message` fetch takes.

Meanwhile, SSE keeps delivering `message.updated` / `message.part.updated` / `session.status` events the whole time — `useEvents`'s `connect()` loop calls `useSessions.getState().handleEvent(...)`, which *does* keep updating `messages`/`parts` in the store — but the screen can't render any of it while `isLoading` is blocking the message list.

If that redundant GET is slow or stalls (flaky mobile network, cold TCP handshake, etc.), the screen looks permanently stuck on "loading" — even though the conversation is progressing live server-side and the store already has (or is receiving) the up-to-date messages. Backing out to the sessions list and re-entering only "fixes" it because it's a fresh retry that happens not to stall the second time — not because anything was actually resolved. This matches the reported repro exactly: stuck loading during an open conversation, fixed only by leaving and re-entering.

## Fix

`src/stores/sessions.ts`:

1. **Don't force the blocking spinner for a same-session re-focus.** `selectSession()` now only sets `isLoading: true` for a genuinely cold load (no session shown yet, or switching to a *different* session) — derived via the new pure `isColdSessionLoad(currentSessionID, targetSessionID)`. Re-selecting the session already on screen refreshes in the background without hiding the (already-live-updating) conversation.
2. **Safety net: any live event proves the screen has data to show.** `handleEvent()` now clears `isLoading` unconditionally whenever a `message.updated`, `message.part.updated`, or `session.updated` event lands for the active session — via the new pure `isLiveEventForSession(eventSessionID, activeSessionID)` (also used to tighten the existing `message.updated` guard). This unsticks the spinner even in the case where the initial GET never resolves at all.

Both are pure functions with no React Native/zustand dependencies, in `src/lib/session-load-reconcile.ts`, unit-tested in `src/lib/session-load-reconcile.test.ts` (7 cases: cold vs. warm load derivation, and live-event session matching including missing/mismatched ids).

Doesn't touch the #121 focus-resync or #123/#124 reconnect-resync code paths — `refreshPending()`, `resyncBusySessions()`, and the `useFocusEffect` re-selection itself are all unchanged; only the `isLoading` gating inside `selectSession`/`handleEvent` changed.

## Testing

- `npm test`: 216/219 passing (3 pre-existing env-gated cancellations, unrelated to this change), including the 7 new `session-load-reconcile.test.ts` cases.
- `npx tsc --noEmit`: clean.

No device test was run (none available in this environment) — reasoned through the state flow instead: reviewed every call site of `selectSession`/`handleEvent`, confirmed the only trigger for `selectSession` is `useFocusEffect` in `app/session/[id].tsx`, and confirmed the fix can't leave `isLoading` stuck (it's only ever forced `true` for a cold load, and always eventually gets set `false` on that load's own success/failure path, plus the new live-event safety net).

### On-device verify steps
1. Open a session and send a message that takes a few seconds to respond (or throttle network in dev tools / airplane-mode-toggle mid-request).
2. While the response is streaming, background the app and foreground it again (or navigate to a modal like the model picker and dismiss it) to force a re-focus — confirm the conversation and streaming response stay visible the whole time, with no spinner flash hiding them.
3. Open a *different* session (cold load) — confirm the spinner still shows briefly as before, since there's nothing to display yet.
4. Simulate a slow/stalled history fetch (e.g. throttle the network right as you open a session that's actively responding) — confirm live SSE updates still render and the screen doesn't get stuck once at least one event arrives, even if the GET itself is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)