### PR TITLE
fix: notification lock-screen leaks, settings persistence + settings screen bugs

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import {
   View,
   Text,
@@ -9,9 +9,11 @@ import {
   useColorScheme,
   Linking,
   Alert,
+  AppState,
 } from "react-native"
 import { Ionicons } from "@expo/vector-icons"
 import { useTranslation } from "react-i18next"
+import appJson from "../../app.json"
 import { useAuth } from "../../src/stores/auth"
 import { useSettings } from "../../src/stores/settings"
 import {
@@ -21,7 +23,7 @@ import {
   granted as notificationsGranted,
 } from "../../src/lib/notifications"
 import type { Category } from "../../src/lib/notifications"
-import { hasTelemetryConsent, setTelemetryConsent } from "../../src/lib/telemetry"
+import { hasTelemetryConsent, loadTelemetryConsent, setTelemetryConsent } from "../../src/lib/telemetry"
 import { PRIVACY_POLICY_URL } from "../../src/lib/links"
 import type { LocalePreference } from "../../src/lib/i18n/locale-resolve"
 
@@ -80,8 +82,42 @@ export default function SettingsScreen() {
   const [telemetryUpdating, setTelemetryUpdating] = useState(false)
 
   // Telemetry consent: hasTelemetryConsent() returns null (unknown), true, or false.
-  // We initialise local state from in-memory value; updates call setTelemetryConsent().
-  const [crashReporting, setCrashReporting] = useState<boolean>(hasTelemetryConsent() ?? false)
+  // Initialize local state from false, then resolve the persisted value in an
+  // effect — the module snapshot can be stale by the time this screen mounts.
+  const [crashReporting, setCrashReporting] = useState<boolean>(false)
+
+  useEffect(() => {
+    let active = true
+    loadTelemetryConsent().then((state) => {
+      if (active) setCrashReporting(state === "granted")
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  // Refresh OS notification permission state on mount and whenever the app
+  // returns to the foreground — the user may toggle it in system Settings.
+  useEffect(() => {
+    let active = true
+    const check = () => {
+      notificationsGranted()
+        .then((ok) => {
+          if (active) setOsGranted(ok)
+        })
+        .catch(() => {
+          if (active) setOsGranted(false)
+        })
+    }
+    check()
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") check()
+    })
+    return () => {
+      active = false
+      sub.remove()
+    }
+  }, [])
 
   const handleCrashReportingToggle = useCallback(
     async (value: boolean) => {
@@ -114,13 +150,6 @@ export default function SettingsScreen() {
     },
     [setNotification, t],
   )
-
-  // Lazy-check OS permission for status display
-  if (osGranted === null) {
-    notificationsGranted()
-      .then(setOsGranted)
-      .catch(() => setOsGranted(false))
-  }
 
   const localeLabels: Record<LocalePreference, string> = {
     system: t("settings.language.system"),
@@ -247,7 +276,7 @@ export default function SettingsScreen() {
           onPress={handleLanguagePress}
           right={<Ionicons name="chevron-forward" size={20} color={isDark ? "#666666" : "#999999"} />}
         />
-        <SettingRow icon="information-circle" label={t("settings.about.version")} description="1.0.0" isDark={isDark} />
+        <SettingRow icon="information-circle" label={t("settings.about.version")} description={(appJson as { expo?: { version?: string } }).expo?.version ?? "unknown"} isDark={isDark} />
         <SettingRow
           icon="logo-github"
           label={t("settings.about.github.label")}

--- a/src/lib/notify-format.test.ts
+++ b/src/lib/notify-format.test.ts
@@ -1,6 +1,11 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { sanitizeBody, MAX_NOTIF_BODY } from "./notify-format.ts"
+import {
+  sanitizeBody,
+  MAX_NOTIF_BODY,
+  permissionNotificationBody,
+  questionNotificationBody,
+} from "./notify-format.ts"
 
 // Notification bodies come from the server (and ultimately the AI). They must be
 // neutralized before display: control chars stripped, whitespace trimmed, length capped.
@@ -38,4 +43,15 @@ test("caps length at MAX_NOTIF_BODY", () => {
 test("trims before slicing so leading whitespace doesn't eat the budget", () => {
   const out = sanitizeBody("   " + "y".repeat(250), "fb")
   assert.equal(out, "y".repeat(MAX_NOTIF_BODY))
+})
+
+test("permissionNotificationBody is a fixed constant (no server content channel)", () => {
+  assert.equal(permissionNotificationBody(), "A tool needs your approval")
+  // No arguments — callers cannot pass server-supplied text through.
+  assert.equal(permissionNotificationBody.length, 0)
+})
+
+test("questionNotificationBody is a fixed constant (no server content channel)", () => {
+  assert.equal(questionNotificationBody(), "The assistant has a question")
+  assert.equal(questionNotificationBody.length, 0)
 })

--- a/src/lib/notify-format.ts
+++ b/src/lib/notify-format.ts
@@ -12,3 +12,27 @@ export const MAX_NOTIF_BODY = 200
 export function sanitizeBody(s: string | undefined, fallback: string): string {
   return (s ? s.replace(/[\x00-\x1f\x7f]/g, " ").trim().slice(0, MAX_NOTIF_BODY) : "") || fallback
 }
+
+/**
+ * Fixed, generic body for permission-request notifications.
+ *
+ * Permissions are server-driven prompts that can carry arbitrary text (the
+ * tool name, patterns, etc.). Rendering that text in the OS notification can
+ * leak server content to the lock screen when the user has not unlocked the
+ * device, and gives a malicious server a free text-injection surface. The
+ * notification body is therefore a constant string; the full detail stays
+ * in-app where the user has authenticated.
+ */
+export function permissionNotificationBody(): string {
+  return "A tool needs your approval"
+}
+
+/**
+ * Fixed, generic body for assistant-question notifications.
+ *
+ * Same lock-screen reasoning as `permissionNotificationBody()`: the question
+ * header/text comes from the server, so it is not echoed into the notification.
+ */
+export function questionNotificationBody(): string {
+  return "The assistant has a question"
+}

--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -2,7 +2,7 @@ import { create } from "zustand"
 import { useConnections } from "./connections"
 import { useSessions, abortedSessions } from "./sessions"
 import { send as notify } from "../lib/notifications"
-import { sanitizeBody } from "../lib/notify-format"
+import { sanitizeBody, permissionNotificationBody, questionNotificationBody } from "../lib/notify-format"
 import { statusFromPart } from "../lib/status-labels"
 import { addBreadcrumb } from "../lib/sentry"
 import { AnalyticsEvent, track } from "../lib/analytics"
@@ -384,14 +384,7 @@ export const useEvents = create<EventsState>((set, get) => ({
               notify({
                 category: "permissions",
                 title: "Agent needs approval",
-                body: sanitizeBody(
-                  req.permission
-                    ? req.patterns?.length
-                      ? `${req.permission}: ${req.patterns.join(", ")}`
-                      : req.permission
-                    : req.patterns?.join(", "),
-                  "A tool needs your approval",
-                ),
+                body: permissionNotificationBody(),
                 sessionId: req.sessionID,
                 dedupeKey: `perm-${req.id}`,
                 dedupeCooldownMs: 60_000,
@@ -425,8 +418,8 @@ export const useEvents = create<EventsState>((set, get) => ({
               }))
               notify({
                 category: "questions",
-                title: req.questions?.[0]?.header || "Input needed",
-                body: sanitizeBody(req.questions?.[0]?.question, "The assistant has a question"),
+                title: "Input needed",
+                body: questionNotificationBody(),
                 sessionId: req.sessionID,
                 dedupeKey: `question-${req.id}`,
                 dedupeCooldownMs: 60_000,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand"
-import * as SecureStore from "expo-secure-store"
+import AsyncStorage from "@react-native-async-storage/async-storage"
 import { type Category, defaultPreferences } from "../lib/notifications"
 import { clampPageSize, mergeStoredSettings } from "../lib/settings-merge"
 import { setAppLocale } from "../lib/i18n/config"
@@ -31,8 +31,11 @@ function snapshot(get: () => SettingsState): Settings {
   return { pageSize: get().pageSize, notifications: get().notifications, locale: get().locale }
 }
 
+// Settings are non-secret user preferences (page size, notification categories,
+// locale) — AsyncStorage is the correct store, not the Keychain-backed
+// SecureStore which should be reserved for credentials.
 async function persist(settings: Settings) {
-  await SecureStore.setItemAsync(SETTINGS_KEY, JSON.stringify(settings))
+  await AsyncStorage.setItem(SETTINGS_KEY, JSON.stringify(settings))
 }
 
 export const useSettings = create<SettingsState>((set, get) => ({
@@ -40,7 +43,7 @@ export const useSettings = create<SettingsState>((set, get) => ({
   loaded: false,
 
   load: async () => {
-    const raw = await SecureStore.getItemAsync(SETTINGS_KEY)
+    const raw = await AsyncStorage.getItem(SETTINGS_KEY)
     if (raw) {
       const parsed = JSON.parse(raw) as Partial<Settings>
       // Merge stored settings with defaults so new fields/categories get their default


### PR DESCRIPTION
## Summary

Ports audit fixes from the fork (`XKILLER2006Y/opencode-mobile`) back to upstream. The fork's main was rebuilt on Expo SDK 57 with no shared history, so a full merge is impossible — these are the audit findings that are cleanly portable to this SDK-54 baseline, hand-adapted and verified.

## Changes

**M-03 — lock-screen notification leaks (security)**
`src/stores/events.ts` + `src/lib/notify-format.ts`: permission and question notifications carried server-supplied content (tool permission/patterns, question header/text) into the OS notification shade. Visible on a locked device, and a malicious server gets a free text-injection surface. Both bodies are now fixed zero-arg constants (`permissionNotificationBody()` / `questionNotificationBody()`) — no server-content channel. Full detail stays in-app where the user is authenticated.

**M-04 — settings persistence**
`src/stores/settings.ts`: settings (page size, notification categories, locale) are non-secret preferences but were stored in Keychain-backed SecureStore. Moved to AsyncStorage.

**Settings screen** (`app/(tabs)/settings.tsx`)
- version reads `app.json` `expo.version` instead of hardcoded `"1.0.0"`
- `crashReporting` initializes `false` and resolves `loadTelemetryConsent()` in an effect (module snapshot can be stale at mount)
- OS notification permission checked in an effect on mount + on `AppState` 'active' (user may toggle it in system Settings), replacing the render-body side effect

## Verification

- `node --test src/lib/notify-format.test.ts`: 9/9 (2 new tests for the zero-arg body functions)
- Full suite: 221/221 pass
- Typecheck: 12 pre-existing errors on upstream main, 12 after — no new errors introduced

## Not included (fork-specific, intentionally)

- U-1 onboarding biometric step (no onboarding screen exists upstream)
- jest test infra (`jest.setup.js` — upstream uses `node --test`)
- prismjs override (no prismjs in upstream lockfile)
