### PR TITLE
security: secret-scan CI gate + persisted-key allowlist tripwire

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,31 @@
+name: Security scan
+
+# Why this exists: the one accurate external report we ever received was
+# Postgres credentials committed to public repo history. The finding itself
+# was cheap to fix; what was missing was a gate that would have caught it
+# before the push. This is that gate.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so a secret introduced in an earlier commit on the
+          # branch is caught, not just the tip diff.
+          fetch-depth: 0
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/lib/persisted-keys.test.ts
+++ b/src/lib/persisted-keys.test.ts
@@ -1,0 +1,84 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import path from "node:path"
+
+/**
+ * Tripwire for the "poisoned persistent memory" class of bug (a scanner
+ * flagged us for it; see the triage in the security notes).
+ *
+ * The app is a thin client: sessions, messages and tool output live on the
+ * opencode server and are held in memory by the zustand stores. Nothing that
+ * a model or a tool produced is ever written to on-device storage, so there
+ * is no persistent store an injected instruction could sit in and be replayed
+ * from on the next launch.
+ *
+ * That property is worth keeping, and it is invisible in review: it only
+ * breaks the day someone adds a well-meaning "cache the last conversation" or
+ * "remember the assistant's summary" write. So: every on-device write is
+ * enumerated here by key. Adding a new one is fine — you just have to come
+ * to this list and say what it holds, which is the moment to ask whether the
+ * value is user/config data or model output.
+ *
+ * Rule: keys listed here must hold user-entered config, consent flags or
+ * counters. Never message text, session titles, tool results or any other
+ * model-derived content.
+ */
+const ALLOWED_PERSISTED_KEYS = new Map<string, string>([
+  ["SETTINGS_KEY", "user's app settings (theme, notification prefs)"],
+  ["CONNECTIONS_KEY", "user-entered server connections"],
+  ["`${PASSWORDS_PREFIX}${id}`", "user-entered server password, per connection"],
+  ["RECENT_DIRS_KEY", "directories the user picked, for the recents list"],
+  ["AUTH_SETTINGS_KEY", "biometric/app-lock preference"],
+  ["COUNT_KEY", "store-review: launch counter"],
+  ["ASKED_KEY", "store-review: already-prompted flag"],
+  ["FIRST_OPEN_KEY", "analytics: first-open flag"],
+  ["CONSENT_KEY", "telemetry consent decision"],
+  ["CHATWOOT_SOURCE_KEY", "support contact id issued by Chatwoot"],
+])
+
+const SRC = path.join(import.meta.dirname, "..")
+
+function sourceFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) return sourceFiles(full)
+    if (!/\.tsx?$/.test(entry.name)) return []
+    if (entry.name.includes(".test.")) return []
+    return [full]
+  })
+}
+
+test("every on-device write uses a reviewed key, never model-generated content", () => {
+  const unknown: string[] = []
+
+  for (const file of sourceFiles(SRC)) {
+    const code = fs.readFileSync(file, "utf8")
+    for (const match of code.matchAll(/SecureStore\.setItemAsync\(\s*([^,]+?)\s*,/g)) {
+      const key = match[1].trim()
+      if (!ALLOWED_PERSISTED_KEYS.has(key)) {
+        unknown.push(`${path.relative(SRC, file)}: ${key}`)
+      }
+    }
+  }
+
+  assert.deepEqual(
+    unknown,
+    [],
+    `New persistent write(s) found. If the value is user config, add the key to ALLOWED_PERSISTED_KEYS ` +
+      `with a note. If it is model or tool output, don't persist it — it comes back as context next launch:\n` +
+      unknown.join("\n"),
+  )
+})
+
+test("the allowlist itself stays live (no keys left behind after a refactor)", () => {
+  const code = sourceFiles(SRC)
+    .map((file) => fs.readFileSync(file, "utf8"))
+    .join("\n")
+  const used = new Set(
+    [...code.matchAll(/SecureStore\.setItemAsync\(\s*([^,]+?)\s*,/g)].map((match) => match[1].trim()),
+  )
+  const stale = [...ALLOWED_PERSISTED_KEYS.keys()].filter((key) => !used.has(key))
+
+  assert.deepEqual(stale, [], `Allowlist entries no longer written anywhere — delete them:\n${stale.join("\n")}`)
+})


### PR DESCRIPTION
Triage outcome for an unsolicited static-scan report (rule `MEM-001`, "LLM-generated content written to a persistent memory store -> cross-session memory poisoning").

## The findings are false positives

| Reported | What is actually there |
| --- | --- |
| `src/lib/notifications.ts:145` | `dedupeSentAt.set(payload.dedupeKey, now)` — module-scope `Map<string, number>` holding a timestamp for a 30s notification cooldown. Not persisted, values are numbers. |
| `src/lib/sdk.ts:392` | `query.set("limit", String(params.limit))` — a `URLSearchParams` on an outbound GET. Not a store at all. |
| `src/lib/session-grouping.ts:24` | `bucket.push(item)` inside `groupByDirectory`, a pure function with no imports. |

The scanner matched `.set(`/`.push(` on identifiers containing "session"/"dedupe". Same for the unnamed "further hits in `src/lib/session-*`": all four of those files are pure reducers over server data with no I/O.

The premise does not hold either. This app is a thin client — sessions, messages and tool output live on the opencode server and are held in memory by the zustand stores. Every on-device write goes through `SecureStore` and stores user-entered config (connections, passwords, recent directories, settings), consent flags or counters. No model-derived content is written to disk, so there is no persistent store an injected instruction could sit in and be replayed from on the next launch. There is also no WebView, no `eval`, and no `Linking.openURL` of a model-supplied URL.

## What is worth adding anyway

- **`.github/workflows/security-scan.yml`** — gitleaks on push/PR to `main`. The one accurate external report we ever received was credentials in public repo history; the finding was cheap to fix, the missing gate was not. This repo still had no secret scanning.
- **`src/lib/persisted-keys.test.ts`** — enumerates every `SecureStore.setItemAsync` key with a note on what it holds. Adding a persistence sink fails the suite until someone adds the key, which is the moment to notice if it is model output rather than config. Confirmed it trips by adding a throwaway "cache the assistant reply" write, then removed it.

Test file is excluded from `tsc` by `tsconfig.json` and runs under the existing `node --test 'src/**/*.test.ts'`; both cases pass locally on node 24+.
