### PR TITLE
fix(waitlist): queue + retry failed signups instead of silently opening mailto

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,6 +19,7 @@ import * as notifications from "../src/lib/notifications"
 import { addBreadcrumb, wrap } from "../src/lib/sentry"
 import { loadTelemetryConsent, setTelemetryConsent } from "../src/lib/telemetry"
 import { initAnalytics, trackAppOpened } from "../src/lib/analytics"
+import { flushPendingSignups } from "../src/lib/waitlist-queue-storage"
 
 const queryClient = new QueryClient()
 
@@ -91,6 +92,30 @@ function RootLayout() {
       if (next === "background" && useAuth.getState().settings.requireBiometric) {
         useAuth.getState().lock()
       }
+    })
+    return () => sub.remove()
+  }, [])
+
+  // Retry any waitlist signup that couldn't reach the server when the user
+  // tapped Join (AGE-87). Runs at cold start and on every foreground, which is
+  // the cheapest reliable proxy for "connectivity may have come back" — it is a
+  // no-op (single storage read, no network) when the queue is empty, and it
+  // replaces the old silent mailto: fallback that lost 20 of 21 signups.
+  useEffect(() => {
+    const flush = () => {
+      void flushPendingSignups()
+        .then((outcome) => {
+          if (outcome.synced.length > 0) {
+            addBreadcrumb({ category: "waitlist", message: `retried ${outcome.synced.length} queued signup(s)` })
+          }
+        })
+        .catch(() => {
+          // Best effort: the entry stays queued for the next foreground.
+        })
+    }
+    flush()
+    const sub = AppState.addEventListener("change", (next) => {
+      if (next === "active") flush()
     })
     return () => sub.remove()
   }, [])

--- a/app/connection/add.tsx
+++ b/app/connection/add.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import {
   View,
   Text,
@@ -21,7 +21,8 @@ import { captureDiagnostic } from "../../src/lib/sentry"
 import { parseUrl } from "../../src/lib/diagnostics-classify"
 import { buildAuth } from "../../src/lib/auth"
 import { AnalyticsEvent, track } from "../../src/lib/analytics"
-import { submitWaitlistSignup, buildWaitlistMailtoUrl } from "../../src/lib/waitlist"
+import { submitWaitlistSignup, buildWaitlistMailtoUrl, needsManualEscapeHatch, type QueuedSignup } from "../../src/lib/waitlist"
+import { flushPendingSignups, queuePendingSignup, readPendingSignups, dropPendingSignup } from "../../src/lib/waitlist-queue-storage"
 
 export default function AddConnectionScreen() {
   const colorScheme = useColorScheme()
@@ -41,7 +42,34 @@ export default function AddConnectionScreen() {
   const [password, setPassword] = useState("")
   const [isConnecting, setIsConnecting] = useState(false)
   const [waitlistEmail, setWaitlistEmail] = useState("")
-  const [waitlistState, setWaitlistState] = useState<"idle" | "submitting" | "joined">("idle")
+  // "queued" = the POST failed but the signup is persisted on-device and will
+  // be retried on the next foreground/connectivity (AGE-87). It is NOT "sent".
+  const [waitlistState, setWaitlistState] = useState<"idle" | "submitting" | "joined" | "queued">("idle")
+  const [pendingSignup, setPendingSignup] = useState<QueuedSignup | null>(null)
+
+  // Retry anything left over from a previous session as soon as this screen
+  // opens (the root layout also flushes on every foreground), then reflect the
+  // real state back to the user instead of pretending nothing is pending.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      const outcome = await flushPendingSignups().catch(() => null)
+      if (cancelled) return
+      const pending = outcome ? outcome.pending : await readPendingSignups().catch(() => [])
+      if (cancelled) return
+      if (outcome && outcome.synced.length > 0 && pending.length === 0) {
+        setWaitlistState("joined")
+        return
+      }
+      if (pending.length > 0) {
+        setPendingSignup(pending[pending.length - 1])
+        setWaitlistState((current) => (current === "idle" ? "queued" : current))
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const buildUrl = () => {
     if (mode === "advanced") return url.trim()
@@ -213,25 +241,70 @@ export default function AddConnectionScreen() {
 
   const handleJoinWaitlist = async () => {
     if (waitlistState === "submitting") return
+    const attemptedEmail = waitlistEmail
     setWaitlistState("submitting")
-    const result = await submitWaitlistSignup(waitlistEmail)
+    const result = await submitWaitlistSignup(attemptedEmail)
     if (result.ok) {
+      // Clear any earlier queued attempt for the same address so the flush
+      // doesn't re-post it.
+      void dropPendingSignup(result.email)
+      setPendingSignup(null)
       setWaitlistState("joined")
       return
     }
-    setWaitlistState("idle")
-    if (result.fallback) {
-      // API unreachable/broken: fall back to the pre-#87 mailto path so the
-      // signup still reaches the support inbox instead of being lost.
-      try {
-        await Linking.openURL(buildWaitlistMailtoUrl(result.email))
-      } catch {
-        // No mail app either — tell the user instead of failing silently.
-        Alert.alert(t("connection.add.waitlist.alertTitle"), t("connection.add.waitlist.fallbackMessage"))
-      }
-    } else {
+
+    if (!result.retryable) {
+      // The server rejected this address; queueing it would retry forever.
+      setWaitlistState(pendingSignup ? "queued" : "idle")
       Alert.alert(t("connection.add.waitlist.alertTitle"), result.error)
+      return
     }
+
+    // Offline / timeout / 5xx: persist and retry later instead of dumping the
+    // user into a mail composer they may never send (AGE-87).
+    const entry = await queuePendingSignup(result.email, result.error)
+    if (entry) {
+      setPendingSignup(entry)
+      setWaitlistState("queued")
+      return
+    }
+
+    // Storage refused the write — we cannot promise to finish this later, so
+    // offer the manual email path explicitly rather than claiming success.
+    setWaitlistState("idle")
+    Alert.alert(t("connection.add.waitlist.alertTitle"), t("connection.add.waitlist.queueFailedMessage"), [
+      { text: t("common.cancel"), style: "cancel" },
+      { text: t("connection.add.waitlist.emailUsButton"), onPress: () => void openWaitlistMailto(result.email) },
+    ])
+  }
+
+  // Last-resort, user-initiated only. Never opened automatically.
+  const openWaitlistMailto = async (email: string) => {
+    try {
+      await Linking.openURL(buildWaitlistMailtoUrl(email))
+    } catch {
+      Alert.alert(t("connection.add.waitlist.alertTitle"), t("connection.add.waitlist.noMailAppMessage"))
+    }
+  }
+
+  // Explicit "Retry" from the queued state — same code path the foreground
+  // flush uses, so there is only one retry implementation.
+  const handleRetryQueued = async () => {
+    setWaitlistState("submitting")
+    const outcome = await flushPendingSignups().catch(() => null)
+    if (outcome && outcome.pending.length === 0 && outcome.synced.length > 0) {
+      setPendingSignup(null)
+      setWaitlistState("joined")
+      return
+    }
+    if (outcome && outcome.pending.length === 0) {
+      // Nothing left pending and nothing synced: the address was rejected.
+      setPendingSignup(null)
+      setWaitlistState("idle")
+      return
+    }
+    if (outcome) setPendingSignup(outcome.pending[outcome.pending.length - 1])
+    setWaitlistState("queued")
   }
 
   // Quick connect mode - simplified
@@ -375,6 +448,27 @@ export default function AddConnectionScreen() {
               <Text style={[styles.waitlistSuccessText, isDark && styles.textDark]}>
                 {t("connection.add.waitlist.successText")}
               </Text>
+            </View>
+          ) : waitlistState === "queued" ? (
+            <View testID="waitlist-queued">
+              <View style={styles.waitlistSuccess}>
+                <Ionicons name="time-outline" size={20} color="#f59e0b" />
+                <Text style={[styles.waitlistSuccessText, isDark && styles.textDark]}>
+                  {t("connection.add.waitlist.queuedText")}
+                </Text>
+              </View>
+              {needsManualEscapeHatch(pendingSignup) && (
+                <TouchableOpacity
+                  style={styles.waitlistEscapeHatch}
+                  onPress={() => void openWaitlistMailto(pendingSignup?.email ?? waitlistEmail)}
+                  testID="waitlist-email-us"
+                >
+                  <Text style={styles.waitlistEscapeHatchText}>{t("connection.add.waitlist.emailUsLink")}</Text>
+                </TouchableOpacity>
+              )}
+              <TouchableOpacity style={styles.waitlistEscapeHatch} onPress={() => void handleRetryQueued()} testID="waitlist-retry">
+                <Text style={styles.waitlistEscapeHatchText}>{t("common.retry")}</Text>
+              </TouchableOpacity>
             </View>
           ) : (
             <>
@@ -833,5 +927,14 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: "#0a0a0a",
     lineHeight: 20,
+  },
+  waitlistEscapeHatch: {
+    marginTop: 8,
+    paddingVertical: 4,
+  },
+  waitlistEscapeHatchText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#6366f1",
   },
 })

--- a/distribution/waitlist-signup-path-coverage.md
+++ b/distribution/waitlist-signup-path-coverage.md
@@ -1,0 +1,59 @@
+# Waitlist signup-path coverage — how much of the install base can't sign up in-app
+
+_Measured 2026-08-14 for [AGE-61]. Re-run with `node scripts/play-version-share.mjs --github`._
+
+## The question
+
+The in-app OpenCode Connect waitlist form posts to `POST /api/beta-signup` (Brevo list 4).
+That code path first shipped in **v0.4.8** (commit `0fdfb54`, 2026-07-18). Every older build
+has exactly one path: open a `mailto:` to support@agentlabs.cc, which lands in a human inbox
+and nowhere near the waitlist store. 20 of 21 signups between 2026-08-03 and 2026-08-13 were
+lost that way. So: **how many people are still on a build with no working signup path?**
+
+## Answer, by channel
+
+| Channel | Population measured | Pre-v0.4.8 share |
+| --- | --- | --- |
+| Google Play (auto-updates) | ~90–100 daily distinct users, 2026-07-31 → 2026-08-13 | **0%** — Play reports a single versionCode, `142` (v0.4.10). Any older build is below Play's reporting floor (<10 users/day). |
+| Sideload — GitHub release APKs (never auto-update) | 1,682 lifetime APK downloads across all releases | **25.9%** (436 downloads) are pre-v0.4.8 builds. |
+
+There is no iOS App Store listing (`itunes.apple.com/lookup?bundleId=cc.agentlabs.opencode`
+returns 0 results) and the app is not on IzzyOnDroid, so those channels contribute nothing.
+
+## What that means
+
+1. **Play is not the problem.** Auto-update did its job: the measurable Android active base is
+   effectively 100% on a build that can sign up through the API.
+2. **The stale cohort is sideload-only and permanent.** ~436 devices pulled an APK that predates
+   the signup API. Nothing will ever update them; they will keep emitting mailto signups until
+   the owner manually re-downloads. The hourly reconciler
+   (`VibeBrowserProductPage/.github/workflows/waitlist-mailto-reconcile.yml`) is what keeps those
+   signups from being lost, and it is not a temporary measure.
+3. **Stale builds are not the only source of mailto signups** — they are, as of AGE-87, the only
+   *remaining* one. Until v0.4.12 the fallback also fired on network error, timeout (8s) and 5xx,
+   so a user on a current build with flaky mobile data took the same lossy path. That path is gone:
+   a failed signup is now persisted on-device (`opencode.waitlist.pending.v1`, AsyncStorage) and
+   retried on every app foreground (`src/lib/waitlist.ts` queue section, flushed from
+   `app/_layout.tsx`). `mailto:` is only ever opened by an explicit user tap after repeated
+   retry failures. Expect the reconciler's `synced_count` to trend toward the sideload cohort only.
+   Any plan that assumes "ship an update and the leak closes" is still wrong for those ~436 devices.
+
+## Method / reproducing
+
+```bash
+GOOGLE_PLAY_SERVICE_ACCOUNT_JSON="$(cat play-store-key.json)" \
+  node scripts/play-version-share.mjs --days 14 --github
+```
+
+- Play numbers come from the Play Developer Reporting API, `crashRateMetricSet` →
+  `distinctUsers` grouped by `versionCode`. That is Play's own vitals denominator: users who
+  actually opened the app. It only covers devices with usage-and-diagnostics sharing on, and Play
+  rounds it — which is why we quote a share, never an absolute install count.
+- Play versionCodes are **not** the ones in `android/app/build.gradle`: the publish workflow
+  overwrites them with `github.run_number + 100`. The mapping in the script was derived from the
+  successful runs of `publish-play-store.yml` (`versionCode 139` = v0.4.8 = first build with the
+  API path).
+- The service account is the same `PLAY_STORE_SERVICE_ACCOUNT_JSON` already used to publish; the
+  script needs only the `playdeveloperreporting` scope and mints its own token, no extra deps.
+
+[AGE-61]: https://github.com/dzianisv/VibeBrowserProductPage/pull/234

--- a/scripts/play-version-share.mjs
+++ b/scripts/play-version-share.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+/**
+ * How many people are still on a build that CANNOT sign up for the waitlist?
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The in-app waitlist form posts to `POST /api/beta-signup` (Brevo list 4). That
+ * path only exists from **v0.4.8 (versionCode 34)** onward. Every older build has
+ * a single fallback: open a `mailto:` to support@agentlabs.cc, which lands in a
+ * human inbox and nowhere near the waitlist store — 20 of 21 signups between
+ * 2026-08-03 and 2026-08-13 were lost that way (AGE-61). Reconciling the inbox
+ * heals the symptom; this script measures the cause, i.e. how much of the live
+ * install base still has no working signup path at all.
+ *
+ * DATA SOURCE
+ * -----------
+ * Google Play Developer Reporting API, `crashRateMetricSet` -> metric
+ * `distinctUsers`, grouped by dimension `versionCode`. That metric set is the only
+ * Play surface that exposes a per-versionCode count of users who ACTUALLY OPENED
+ * the app in a period (Play's own vitals denominator), which is what "active
+ * install" should mean here. Play install reports (GCS bucket) count devices that
+ * merely have the APK, and need a second credential; this needs only the
+ * androidpublisher service account we already ship to CI.
+ *
+ * CAVEAT, stated up front so the number is not over-read: Play vitals only sees
+ * devices whose owner left "share usage & diagnostics" on. It is a large, unbiased
+ * -enough SAMPLE of the install base, not a census. Shares are therefore reported
+ * as shares (ratio between versions inside the same sample), which is exactly the
+ * quantity we care about, and never as an absolute install count.
+ *
+ * SECOND CHANNEL (why Play alone is not the answer)
+ * -------------------------------------------------
+ * Play auto-updates, so its active base converges on the newest build fast. The
+ * cohort that stays stale forever is the SIDELOAD channel: GitHub release APKs
+ * (also what the F-Droid-style builds are downloaded from). Those installs never
+ * auto-update, so a device that pulled a pre-v0.4.8 APK still has mailto as its
+ * ONLY signup path today. `--github` adds lifetime APK downloads per release
+ * from the public GitHub API, which is the honest denominator for that channel.
+ *
+ * USAGE
+ *   GOOGLE_PLAY_SERVICE_ACCOUNT_JSON='<sa json>' node scripts/play-version-share.mjs
+ *   ... --github         also report sideload (GitHub release APK) version share
+ *   ... --json           machine-readable output only
+ *   ... --days 14        window to scan (default 7 available days)
+ *
+ * Exits non-zero only on hard failure (auth, API, no data at all) — a bad share is
+ * a finding, not a crash.
+ */
+
+import { createSign } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+const PACKAGE_NAME = process.env.PLAY_PACKAGE_NAME || "cc.agentlabs.opencode";
+/**
+ * CAREFUL: Play versionCodes are NOT the ones in android/app/build.gradle. The
+ * publish workflow overwrites them with `github.run_number + 100`
+ * (.github/workflows/publish-play-store.yml), so the gradle/tag mapping is
+ * meaningless on Play. The table below was derived from the publish runs:
+ *
+ *   gh api repos/dzianisv/opencode-mobile/actions/workflows/278415225/runs \
+ *     --jq '.workflow_runs[]|select(.conclusion=="success")|"\(.run_number+100) \(.head_sha)"'
+ *   # then, per sha: version from package.json, API path via
+ *   #   git merge-base --is-ancestor 0fdfb54 <sha>   (0fdfb54 = the beta-signup call)
+ *
+ * versionCode 139 (v0.4.8, 2026-07-18) is the first Play build that contains it.
+ */
+const FIRST_API_SIGNUP_VERSION_CODE = Number(process.env.FIRST_API_SIGNUP_VERSION_CODE || 139);
+const VERSION_NAMES = {
+  119: "0.4.1",
+  120: "0.4.1",
+  123: "0.4.1",
+  126: "0.4.2",
+  127: "0.4.3",
+  128: "0.4.3",
+  129: "0.4.3",
+  130: "0.4.3",
+  132: "0.4.5",
+  133: "0.4.5",
+  134: "0.4.5",
+  135: "0.4.5",
+  136: "0.4.5",
+  137: "0.4.6",
+  138: "0.4.7",
+  139: "0.4.8",
+  141: "0.4.9",
+  142: "0.4.10",
+  143: "0.4.11",
+  146: "0.4.12",
+};
+
+const args = process.argv.slice(2);
+const jsonOnly = args.includes("--json");
+const withGithub = args.includes("--github");
+const days = Number(args[args.indexOf("--days") + 1]) || 7;
+
+/** Semver compare limited to what our tags use (`vX.Y.Z`). */
+function isPreApiSignupTag(tag) {
+  const parts = tag.replace(/^v/, "").split(".").map(Number);
+  const [major, minor, patch] = [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+  if (major !== 0) return major < 0;
+  if (minor !== 4) return minor < 4;
+  return patch < 8; // v0.4.8 is the first release with POST /api/beta-signup
+}
+
+/**
+ * Sideload share: lifetime APK downloads per GitHub release. Downloads are not
+ * installs — some are CI, mirrors or curiosity — but they are the only per-version
+ * signal this channel emits, and the ratio is what we quote, never the absolute.
+ */
+async function githubSideloadShare() {
+  const repo = process.env.GITHUB_RELEASES_REPO || "dzianisv/opencode-mobile";
+  const headers = { accept: "application/vnd.github+json" };
+  if (process.env.GH_TOKEN || process.env.GITHUB_TOKEN)
+    headers.authorization = `Bearer ${process.env.GH_TOKEN || process.env.GITHUB_TOKEN}`;
+  const res = await fetch(`https://api.github.com/repos/${repo}/releases?per_page=100`, { headers });
+  if (!res.ok) throw new Error(`github releases failed (${res.status})`);
+  const releases = await res.json();
+  const rows = releases.map((r) => ({
+    tag: r.tag_name,
+    downloads: (r.assets || [])
+      .filter((a) => /\.apk$/i.test(a.name))
+      .reduce((sum, a) => sum + (a.download_count || 0), 0),
+    preApiSignup: isPreApiSignupTag(r.tag_name),
+  }));
+  const total = rows.reduce((s, r) => s + r.downloads, 0);
+  const stale = rows.filter((r) => r.preApiSignup).reduce((s, r) => s + r.downloads, 0);
+  return { repo, rows, totalDownloads: total, staleDownloads: stale, staleShare: total ? stale / total : 0 };
+}
+
+function loadServiceAccount() {
+  const raw =
+    process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON ||
+    (process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_FILE
+      ? readFileSync(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_FILE, "utf8")
+      : "");
+  if (!raw.trim()) {
+    throw new Error(
+      "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON (or _FILE) is required — refusing to report a share from no data",
+    );
+  }
+  const sa = JSON.parse(raw);
+  if (!sa.client_email || !sa.private_key) throw new Error("service account JSON is missing client_email/private_key");
+  return sa;
+}
+
+/** Mint an access token straight from the SA key (no googleapis dependency). */
+async function getAccessToken(sa) {
+  const scope = "https://www.googleapis.com/auth/playdeveloperreporting";
+  const now = Math.floor(Date.now() / 1000);
+  const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  const claim = `${b64({ alg: "RS256", typ: "JWT" })}.${b64({
+    iss: sa.client_email,
+    scope,
+    aud: sa.token_uri || "https://oauth2.googleapis.com/token",
+    iat: now,
+    exp: now + 3600,
+  })}`;
+  const signature = createSign("RSA-SHA256").update(claim).sign(sa.private_key).toString("base64url");
+  const res = await fetch(sa.token_uri || "https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: `${claim}.${signature}`,
+    }),
+  });
+  const body = await res.json();
+  if (!res.ok) throw new Error(`token exchange failed (${res.status}): ${JSON.stringify(body)}`);
+  return body.access_token;
+}
+
+async function api(path, token, init = {}) {
+  const res = await fetch(`https://playdeveloperreporting.googleapis.com/v1beta1/${path}`, {
+    ...init,
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json", ...(init.headers || {}) },
+  });
+  const body = await res.json();
+  if (!res.ok) throw new Error(`${path} failed (${res.status}): ${JSON.stringify(body).slice(0, 400)}`);
+  return body;
+}
+
+/** Play publishes vitals with a lag; ask the API how fresh DAILY data actually is. */
+function latestDailyDate(metricSet) {
+  const daily = (metricSet.freshnessInfo?.freshnesses || []).find((f) => f.aggregationPeriod === "DAILY");
+  const d = daily?.latestEndTime;
+  if (!d) return null;
+  return { year: d.year, month: d.month, day: d.day };
+}
+
+function addDays({ year, month, day }, delta) {
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  dt.setUTCDate(dt.getUTCDate() + delta);
+  return { year: dt.getUTCFullYear(), month: dt.getUTCMonth() + 1, day: dt.getUTCDate() };
+}
+
+const fmt = (d) => `${d.year}-${String(d.month).padStart(2, "0")}-${String(d.day).padStart(2, "0")}`;
+
+async function main() {
+  const token = await getAccessToken(loadServiceAccount());
+  const metricSet = await api(`apps/${PACKAGE_NAME}/crashRateMetricSet`, token);
+  const end = latestDailyDate(metricSet);
+  if (!end) throw new Error("Play reports no DAILY freshness for crashRateMetricSet — cannot date the window");
+  const start = addDays(end, -(days - 1));
+
+  const rows = [];
+  let pageToken;
+  do {
+    const body = await api(`apps/${PACKAGE_NAME}/crashRateMetricSet:query`, token, {
+      method: "POST",
+      body: JSON.stringify({
+        timelineSpec: {
+          aggregationPeriod: "DAILY",
+          startTime: { ...start, timeZone: { id: "America/Los_Angeles" } },
+          // Play rejects any endTime past its published freshness date, so the
+          // freshest available day IS the end of the window.
+          endTime: { ...end, timeZone: { id: "America/Los_Angeles" } },
+        },
+        dimensions: ["versionCode"],
+        metrics: ["distinctUsers"],
+        pageSize: 1000,
+        pageToken,
+      }),
+    });
+    rows.push(...(body.rows || []));
+    pageToken = body.nextPageToken;
+  } while (pageToken);
+
+  if (rows.length === 0) throw new Error("Play returned zero rows — no vitals data for this app/window");
+
+  // Per version, take the PEAK daily distinct users in the window. Summing across
+  // days would double-count the same person opening the app on several days; the
+  // peak is the closest honest read of "how many humans are on this build".
+  const peak = new Map();
+  for (const row of rows) {
+    // Play returns the versionCode as `stringValue` even though it is numeric.
+    const dim = row.dimensions?.find((d) => d.dimension === "versionCode");
+    const code = Number(dim?.stringValue ?? dim?.int64Value);
+    const users = Number(row.metrics?.find((m) => m.metric === "distinctUsers")?.decimalValue?.value ?? 0);
+    if (!Number.isFinite(code)) continue;
+    peak.set(code, Math.max(peak.get(code) ?? 0, users));
+  }
+
+  const versions = [...peak.entries()]
+    .map(([versionCode, users]) => ({
+      versionCode,
+      version: VERSION_NAMES[versionCode] || "unknown",
+      users,
+      canSignUpInApp: versionCode >= FIRST_API_SIGNUP_VERSION_CODE,
+    }))
+    .sort((a, b) => b.users - a.users);
+
+  const total = versions.reduce((sum, v) => sum + v.users, 0);
+  const stale = versions.filter((v) => !v.canSignUpInApp).reduce((sum, v) => sum + v.users, 0);
+  const result = {
+    packageName: PACKAGE_NAME,
+    window: { start: fmt(start), end: fmt(end), days },
+    firstApiSignupVersionCode: FIRST_API_SIGNUP_VERSION_CODE,
+    metric: "crashRateMetricSet/distinctUsers (peak day per versionCode)",
+    versions,
+    totalUsers: total,
+    staleUsers: stale,
+    staleShare: total > 0 ? stale / total : 0,
+  };
+
+  if (withGithub) result.sideload = await githubSideloadShare();
+
+  if (jsonOnly) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.log(`Play version share — ${PACKAGE_NAME}  (${fmt(start)} → ${fmt(end)}, peak daily distinct users)`);
+  console.log("");
+  console.log("| versionCode | version | users | in-app signup works |");
+  console.log("| --- | --- | --- | --- |");
+  for (const v of versions) {
+    console.log(`| ${v.versionCode} | ${v.version} | ${v.users} | ${v.canSignUpInApp ? "yes" : "NO — mailto only"} |`);
+  }
+  console.log("");
+  console.log(
+    `pre-v0.4.8 (versionCode < ${FIRST_API_SIGNUP_VERSION_CODE}): ${stale} of ${total} users = ` +
+      `${(result.staleShare * 100).toFixed(1)}% have NO in-app signup path.`,
+  );
+  if (result.sideload) {
+    const s = result.sideload;
+    console.log("");
+    console.log(`Sideload channel — ${s.repo} release APKs (lifetime downloads, never auto-update)`);
+    console.log("");
+    console.log("| tag | apk downloads | in-app signup works |");
+    console.log("| --- | --- | --- |");
+    for (const r of s.rows.filter((r) => r.downloads > 0))
+      console.log(`| ${r.tag} | ${r.downloads} | ${r.preApiSignup ? "NO — mailto only" : "yes"} |`);
+    console.log("");
+    console.log(
+      `pre-v0.4.8 sideloads: ${s.staleDownloads} of ${s.totalDownloads} = ` +
+        `${(s.staleShare * 100).toFixed(1)}% of this channel can never sign up in-app without a manual re-download.`,
+    );
+  }
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(process.env.GITHUB_OUTPUT, `stale_share=${(result.staleShare * 100).toFixed(1)}\n`);
+    appendFileSync(process.env.GITHUB_OUTPUT, `stale_users=${stale}\ntotal_users=${total}\n`);
+  }
+}
+
+main().catch((err) => {
+  console.error(`play-version-share: ${err.message}`);
+  process.exit(1);
+});

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -181,7 +181,11 @@
         "successText": "You're on the list — we'll email you when OpenCode Connect is ready.",
         "joinButton": "Join Waitlist",
         "alertTitle": "Join Waitlist",
-        "fallbackMessage": "Could not reach the signup service or open an email app. Please email support@agentlabs.cc with subject \"OpenCode Connect Waitlist\"."
+        "queuedText": "Saved on this device — we'll finish signing you up as soon as you're back online. You don't have to do anything.",
+        "emailUsLink": "Still not working? Email us instead",
+        "emailUsButton": "Email us",
+        "queueFailedMessage": "We couldn't reach the signup service or save your request on this device. You can email us instead and we'll add you by hand.",
+        "noMailAppMessage": "No email app is available. Please email support@agentlabs.cc with subject \"OpenCode Connect Waitlist\"."
       },
       "advanced": {
         "backToQuick": "Simple mode",

--- a/src/lib/i18n/zh-Hans.json
+++ b/src/lib/i18n/zh-Hans.json
@@ -181,7 +181,11 @@
         "successText": "您已加入候补名单 — OpenCode Connect 准备就绪时我们会通过邮件通知您。",
         "joinButton": "加入候补名单",
         "alertTitle": "加入候补名单",
-        "fallbackMessage": "无法连接注册服务或打开邮件应用。请发送邮件至 support@agentlabs.cc，主题为 \"OpenCode Connect Waitlist\"。"
+        "queuedText": "已保存在此设备上 — 联网后我们会自动完成注册，你无需再做任何操作。",
+        "emailUsLink": "仍然无法注册？改为给我们发邮件",
+        "emailUsButton": "发送邮件",
+        "queueFailedMessage": "无法连接注册服务，也无法在此设备上保存你的请求。你可以改为给我们发邮件，我们会手动将你加入名单。",
+        "noMailAppMessage": "没有可用的邮件应用。请发送邮件至 support@agentlabs.cc，主题为 \"OpenCode Connect Waitlist\"。"
       },
       "advanced": {
         "backToQuick": "简易模式",

--- a/src/lib/waitlist-queue-storage.ts
+++ b/src/lib/waitlist-queue-storage.ts
@@ -1,0 +1,35 @@
+// Production wiring for the waitlist retry queue (AGE-87).
+//
+// Split out from waitlist-queue.ts so the queue logic stays importable by
+// `node --test` (no react-native / AsyncStorage native module). This file is
+// the only place that touches device storage.
+//
+// AsyncStorage (not SecureStore) on purpose: a pending waitlist email is not a
+// credential, and this queue must survive a keychain that refuses to unlock —
+// the whole point is that the signup is never silently lost.
+
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import { flushQueue, loadQueue, enqueueSignup, removeFromQueue, type FlushOutcome, type QueuedSignup, type QueueStorage } from "./waitlist"
+
+const storage: QueueStorage = {
+  getItem: (key) => AsyncStorage.getItem(key),
+  setItem: (key, value) => AsyncStorage.setItem(key, value),
+  removeItem: (key) => AsyncStorage.removeItem(key),
+}
+
+export function queuePendingSignup(email: string, error?: string): Promise<QueuedSignup | null> {
+  return enqueueSignup(storage, email, { error })
+}
+
+export function readPendingSignups(): Promise<QueuedSignup[]> {
+  return loadQueue(storage)
+}
+
+export function dropPendingSignup(email: string): Promise<void> {
+  return removeFromQueue(storage, email)
+}
+
+/** Best-effort retry of every pending signup. Safe to call on every foreground. */
+export function flushPendingSignups(): Promise<FlushOutcome> {
+  return flushQueue(storage)
+}

--- a/src/lib/waitlist-queue.test.ts
+++ b/src/lib/waitlist-queue.test.ts
@@ -1,0 +1,244 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import {
+  WAITLIST_QUEUE_KEY,
+  WAITLIST_QUEUE_MAX,
+  WAITLIST_QUEUE_TTL_MS,
+  enqueueSignup,
+  flushQueue,
+  loadQueue,
+  needsManualEscapeHatch,
+  pruneQueue,
+  removeFromQueue,
+  type QueueStorage,
+  type QueuedSignup,
+  type WaitlistResult,
+} from "./waitlist.ts"
+
+// In-memory stand-in for AsyncStorage. `fail` makes every write throw, which is
+// how a device with full/locked storage behaves.
+function memoryStorage(initial?: string, opts: { failWrites?: boolean } = {}) {
+  const map = new Map<string, string>()
+  if (initial !== undefined) map.set(WAITLIST_QUEUE_KEY, initial)
+  const storage: QueueStorage & { map: Map<string, string> } = {
+    map,
+    async getItem(key) {
+      return map.get(key) ?? null
+    },
+    async setItem(key, value) {
+      if (opts.failWrites) throw new Error("storage full")
+      map.set(key, value)
+    },
+    async removeItem(key) {
+      if (opts.failWrites) throw new Error("storage full")
+      map.delete(key)
+    },
+  }
+  return storage
+}
+
+function stored(storage: { map: Map<string, string> }): QueuedSignup[] {
+  const raw = storage.map.get(WAITLIST_QUEUE_KEY)
+  return raw ? (JSON.parse(raw) as QueuedSignup[]) : []
+}
+
+const ok = (email: string): WaitlistResult => ({ ok: true, email })
+const offline = (email: string): WaitlistResult => ({ ok: false, email, retryable: true, error: "Network request failed" })
+const rejected = (email: string): WaitlistResult => ({ ok: false, email, retryable: false, error: "Enter a valid email address." })
+
+// --- enqueue ---
+
+test("enqueue persists a normalized signup with attempt 1", async () => {
+  const storage = memoryStorage()
+  const entry = await enqueueSignup(storage, "  Dev@Example.COM ", { now: 1_000, error: "Network request failed" })
+  assert.deepEqual(entry, {
+    email: "dev@example.com",
+    queuedAt: 1_000,
+    attempts: 1,
+    lastAttemptAt: 1_000,
+    lastError: "Network request failed",
+  })
+  assert.deepEqual(stored(storage), [entry])
+})
+
+test("enqueue dedupes by email and bumps attempts instead of growing the queue", async () => {
+  const storage = memoryStorage()
+  await enqueueSignup(storage, "dev@example.com", { now: 1_000 })
+  const second = await enqueueSignup(storage, "DEV@example.com", { now: 2_000 })
+  assert.equal(stored(storage).length, 1)
+  assert.equal(second?.attempts, 2)
+  assert.equal(second?.queuedAt, 1_000, "original queue time is preserved")
+  assert.equal(second?.lastAttemptAt, 2_000)
+})
+
+test("enqueue caps the queue at WAITLIST_QUEUE_MAX, keeping the newest", async () => {
+  const storage = memoryStorage()
+  for (let i = 0; i < WAITLIST_QUEUE_MAX + 3; i++) {
+    await enqueueSignup(storage, `user${i}@example.com`, { now: 1_000 + i })
+  }
+  const queue = stored(storage)
+  assert.equal(queue.length, WAITLIST_QUEUE_MAX)
+  assert.equal(queue[queue.length - 1].email, `user${WAITLIST_QUEUE_MAX + 2}@example.com`)
+})
+
+test("enqueue refuses an invalid email — nothing is stored, caller must not claim success", async () => {
+  const storage = memoryStorage()
+  assert.equal(await enqueueSignup(storage, "not-an-email"), null)
+  assert.equal(storage.map.size, 0)
+})
+
+test("enqueue returns null when storage refuses the write (never lie about saving)", async () => {
+  const storage = memoryStorage(undefined, { failWrites: true })
+  assert.equal(await enqueueSignup(storage, "dev@example.com", { now: 1 }), null)
+})
+
+// --- load resilience: a corrupt blob must not brick the screen ---
+
+test("load tolerates missing, corrupt, non-array and foreign-shaped payloads", async () => {
+  assert.deepEqual(await loadQueue(memoryStorage()), [])
+  assert.deepEqual(await loadQueue(memoryStorage("{not json")), [])
+  assert.deepEqual(await loadQueue(memoryStorage('{"email":"a@b.co"}')), [])
+  assert.deepEqual(await loadQueue(memoryStorage('[{"nope":1},null,3]')), [])
+  assert.deepEqual(
+    await loadQueue(memoryStorage('[{"email":"NOT normalized","queuedAt":1,"attempts":1}]')),
+    [],
+    "entries that were never normalized are dropped rather than replayed as garbage",
+  )
+})
+
+test("load backfills lastAttemptAt for entries written before that field existed", async () => {
+  const storage = memoryStorage('[{"email":"dev@example.com","queuedAt":42,"attempts":1}]')
+  assert.deepEqual(await loadQueue(storage), [
+    { email: "dev@example.com", queuedAt: 42, attempts: 1, lastAttemptAt: 42 },
+  ])
+})
+
+test("load survives a storage read that throws", async () => {
+  const storage: QueueStorage = {
+    async getItem() {
+      throw new Error("AsyncStorage unavailable")
+    },
+    async setItem() {},
+    async removeItem() {},
+  }
+  assert.deepEqual(await loadQueue(storage), [])
+})
+
+// --- TTL ---
+
+test("entries older than the TTL are pruned", () => {
+  const fresh: QueuedSignup = { email: "a@b.co", queuedAt: 1_000, attempts: 1, lastAttemptAt: 1_000 }
+  const stale: QueuedSignup = { email: "c@d.co", queuedAt: 0, attempts: 9, lastAttemptAt: 0 }
+  assert.deepEqual(pruneQueue([fresh, stale], WAITLIST_QUEUE_TTL_MS + 500), [fresh])
+})
+
+// --- flush: the AGE-87 acceptance test ---
+
+test("offline signup reaches the server on the next flush, with no mail client involved", async () => {
+  const storage = memoryStorage()
+
+  // 1. User taps "Join Waitlist" on a plane: the POST fails, we queue it.
+  const failure = offline("dev@example.com")
+  assert.equal(failure.ok, false)
+  const queued = await enqueueSignup(storage, "dev@example.com", { now: 1_000, error: failure.error })
+  assert.equal(queued?.attempts, 1)
+
+  // 2. Still offline on the next foreground: kept, attempts bumped.
+  const attempted: string[] = []
+  const stillOffline = await flushQueue(storage, {
+    now: 2_000,
+    submit: async (email) => {
+      attempted.push(email)
+      return offline(email)
+    },
+  })
+  assert.deepEqual(stillOffline.synced, [])
+  assert.deepEqual(stillOffline.pending.map((e) => e.attempts), [2])
+  assert.deepEqual(stored(storage).map((e) => e.email), ["dev@example.com"])
+
+  // 3. Device reconnects: the queued signup lands in Brevo list 4 and the
+  //    queue empties. No mailto: URL was ever built.
+  const reconnected = await flushQueue(storage, {
+    now: 3_000,
+    submit: async (email) => {
+      attempted.push(email)
+      return ok(email)
+    },
+  })
+  assert.deepEqual(reconnected.synced, ["dev@example.com"])
+  assert.deepEqual(reconnected.pending, [])
+  assert.equal(storage.map.has(WAITLIST_QUEUE_KEY), false, "queue key is removed once empty")
+  assert.deepEqual(attempted, ["dev@example.com", "dev@example.com"])
+})
+
+test("flush drops entries the server permanently rejects (4xx) instead of retrying forever", async () => {
+  const storage = memoryStorage()
+  await enqueueSignup(storage, "dev@example.com", { now: 1 })
+  const outcome = await flushQueue(storage, { now: 2, submit: async (email) => rejected(email) })
+  assert.deepEqual(outcome.rejected, ["dev@example.com"])
+  assert.deepEqual(outcome.pending, [])
+  assert.deepEqual(stored(storage), [])
+})
+
+test("flush keeps the other entries when one submit throws", async () => {
+  const storage = memoryStorage()
+  await enqueueSignup(storage, "a@example.com", { now: 1 })
+  await enqueueSignup(storage, "b@example.com", { now: 2 })
+  const outcome = await flushQueue(storage, {
+    now: 3,
+    submit: async (email) => {
+      if (email === "a@example.com") throw new TypeError("boom")
+      return ok(email)
+    },
+  })
+  assert.deepEqual(outcome.synced, ["b@example.com"])
+  assert.deepEqual(outcome.pending.map((e) => e.email), ["a@example.com"])
+  assert.match(outcome.pending[0].lastError ?? "", /boom/)
+})
+
+test("flush prunes expired entries without submitting them", async () => {
+  const storage = memoryStorage()
+  await enqueueSignup(storage, "old@example.com", { now: 0 })
+  let called = 0
+  const outcome = await flushQueue(storage, {
+    now: WAITLIST_QUEUE_TTL_MS + 1,
+    submit: async (email) => {
+      called++
+      return ok(email)
+    },
+  })
+  assert.equal(called, 0)
+  assert.deepEqual(outcome, { synced: [], rejected: [], pending: [] })
+  assert.deepEqual(stored(storage), [])
+})
+
+test("flush on an empty queue is a no-op", async () => {
+  const storage = memoryStorage()
+  const outcome = await flushQueue(storage, { submit: async () => assert.fail("must not submit") })
+  assert.deepEqual(outcome, { synced: [], rejected: [], pending: [] })
+})
+
+// --- manual escape hatch policy ---
+
+test("the manual email escape hatch appears only after repeated failures", async () => {
+  const storage = memoryStorage()
+  let entry = await enqueueSignup(storage, "dev@example.com", { now: 1 })
+  assert.equal(needsManualEscapeHatch(entry), false)
+  entry = await enqueueSignup(storage, "dev@example.com", { now: 2 })
+  assert.equal(needsManualEscapeHatch(entry), false)
+  entry = await enqueueSignup(storage, "dev@example.com", { now: 3 })
+  assert.equal(needsManualEscapeHatch(entry), true, "3rd failed attempt -> offer 'still not working? email us'")
+  assert.equal(needsManualEscapeHatch(null), false)
+})
+
+// --- explicit removal ---
+
+test("removeFromQueue drops just that email", async () => {
+  const storage = memoryStorage()
+  await enqueueSignup(storage, "a@example.com", { now: 1 })
+  await enqueueSignup(storage, "b@example.com", { now: 2 })
+  await removeFromQueue(storage, "a@example.com")
+  assert.deepEqual(stored(storage).map((e) => e.email), ["b@example.com"])
+  await removeFromQueue(storage, "missing@example.com") // no-op, no throw
+  assert.deepEqual(stored(storage).map((e) => e.email), ["b@example.com"])
+})

--- a/src/lib/waitlist.test.ts
+++ b/src/lib/waitlist.test.ts
@@ -6,7 +6,7 @@ import {
   normalizeWaitlistEmail,
   buildWaitlistPayload,
   buildWaitlistMailtoUrl,
-  shouldFallbackToMailto,
+  isRetryableFailure,
   submitWaitlistSignup,
 } from "./waitlist.ts"
 
@@ -34,32 +34,32 @@ test("payload tags the signup with the opencode-connect source", () => {
   })
 })
 
-// --- mailto fallback URL: byte-compatible with the pre-#87 behavior ---
+// --- mailto URL: last-resort escape hatch only (AGE-87), byte-compatible ---
 
-test("mailto fallback preserves subject and embeds the email", () => {
+test("mailto escape hatch preserves subject and embeds the email", () => {
   const url = buildWaitlistMailtoUrl("dev@example.com")
   assert.ok(url.startsWith("mailto:support@agentlabs.cc?"))
   assert.ok(url.includes("subject=OpenCode%20Connect%20Waitlist"))
   assert.ok(url.includes(encodeURIComponent("Email: dev@example.com")))
 })
 
-test("mailto fallback works without an email", () => {
+test("mailto escape hatch works without an email", () => {
   const url = buildWaitlistMailtoUrl("")
   assert.ok(url.includes("body=Sign%20me%20up!"))
   assert.ok(!url.includes("Email"))
 })
 
-// --- fallback decision ---
+// --- retry decision ---
 
 // 502 named explicitly: the server returns it when Brevo itself fails, and the
-// signup must survive that via mailto.
-test("fallback: transport failures and 5xx (incl. 502 Brevo failure) -> mailto, 4xx -> fix input", () => {
-  assert.equal(shouldFallbackToMailto({ kind: "network-error" }), true)
-  assert.equal(shouldFallbackToMailto({ kind: "http", status: 500 }), true)
-  assert.equal(shouldFallbackToMailto({ kind: "http", status: 502 }), true)
-  assert.equal(shouldFallbackToMailto({ kind: "http", status: 503 }), true)
-  assert.equal(shouldFallbackToMailto({ kind: "http", status: 400 }), false)
-  assert.equal(shouldFallbackToMailto({ kind: "http", status: 429 }), false)
+// signup must survive that by being queued and retried (AGE-87), not mailed.
+test("retryable: transport failures and 5xx (incl. 502 Brevo failure) -> retry, 4xx -> fix input", () => {
+  assert.equal(isRetryableFailure({ kind: "network-error" }), true)
+  assert.equal(isRetryableFailure({ kind: "http", status: 500 }), true)
+  assert.equal(isRetryableFailure({ kind: "http", status: 502 }), true)
+  assert.equal(isRetryableFailure({ kind: "http", status: 503 }), true)
+  assert.equal(isRetryableFailure({ kind: "http", status: 400 }), false)
+  assert.equal(isRetryableFailure({ kind: "http", status: 429 }), false)
 })
 
 // --- submitWaitlistSignup with injected fetch ---
@@ -89,37 +89,37 @@ test("submit rejects an invalid email locally without hitting the network", asyn
   const calls: FetchCall[] = []
   const result = await submitWaitlistSignup("nope", { fetchFn: fakeFetch({ ok: true, status: 200 }, calls) })
   assert.equal(calls.length, 0)
-  assert.deepEqual(result, { ok: false, email: "nope", fallback: false, error: "Enter a valid email address." })
+  assert.deepEqual(result, { ok: false, email: "nope", retryable: false, error: "Enter a valid email address." })
 })
 
-test("submit surfaces the server's 400 message without falling back to mailto", async () => {
+test("submit surfaces the server's 400 message and marks it non-retryable", async () => {
   const result = await submitWaitlistSignup("dev@example.com", {
     fetchFn: fakeFetch({ ok: false, status: 400, body: { error: "Enter a valid email address." } }),
   })
-  assert.deepEqual(result, { ok: false, email: "dev@example.com", fallback: false, error: "Enter a valid email address." })
+  assert.deepEqual(result, { ok: false, email: "dev@example.com", retryable: false, error: "Enter a valid email address." })
 })
 
-test("submit falls back to mailto on 5xx (server broken, keep the signup alive)", async () => {
+test("submit marks 5xx retryable (server broken, keep the signup alive)", async () => {
   const result = await submitWaitlistSignup("dev@example.com", {
     fetchFn: fakeFetch({ ok: false, status: 503, body: { error: "The waitlist is temporarily unavailable. Please try again later." } }),
   })
   assert.equal(result.ok, false)
   if (!result.ok) {
-    assert.equal(result.fallback, true)
+    assert.equal(result.retryable, true)
     assert.equal(result.error, "The waitlist is temporarily unavailable. Please try again later.")
   }
 })
 
-test("submit falls back to mailto when fetch rejects (offline)", async () => {
+test("submit marks a rejected fetch retryable (offline)", async () => {
   const result = await submitWaitlistSignup("dev@example.com", {
     fetchFn: async () => {
       throw new TypeError("Network request failed")
     },
   })
-  assert.deepEqual(result, { ok: false, email: "dev@example.com", fallback: true, error: "Network request failed" })
+  assert.deepEqual(result, { ok: false, email: "dev@example.com", retryable: true, error: "Network request failed" })
 })
 
-test("submit aborts after timeoutMs and falls back to mailto", async () => {
+test("submit aborts after timeoutMs and marks it retryable", async () => {
   const result = await submitWaitlistSignup("dev@example.com", {
     timeoutMs: 20,
     fetchFn: (_url, init) =>
@@ -131,7 +131,7 @@ test("submit aborts after timeoutMs and falls back to mailto", async () => {
         })
       }),
   })
-  assert.deepEqual(result, { ok: false, email: "dev@example.com", fallback: true, error: "timeout after 20ms" })
+  assert.deepEqual(result, { ok: false, email: "dev@example.com", retryable: true, error: "timeout after 20ms" })
 })
 
 test("submit tolerates a non-JSON error body", async () => {
@@ -144,5 +144,5 @@ test("submit tolerates a non-JSON error body", async () => {
       },
     }),
   })
-  assert.deepEqual(result, { ok: false, email: "dev@example.com", fallback: true, error: "Signup failed (HTTP 502)." })
+  assert.deepEqual(result, { ok: false, email: "dev@example.com", retryable: true, error: "Signup failed (HTTP 502)." })
 })

--- a/src/lib/waitlist.ts
+++ b/src/lib/waitlist.ts
@@ -31,7 +31,12 @@ export function buildWaitlistPayload(email: string): { email: string; source: st
   return { email, source: WAITLIST_SOURCE }
 }
 
-/** The pre-#87 mailto path, kept as the fallback when the API is unreachable. */
+/**
+ * Last-resort, USER-INITIATED escape hatch (AGE-87). Never open this
+ * automatically: a failed signup is queued locally and retried
+ * (waitlist-queue.ts). This URL is only offered after retries keep failing,
+ * behind an explicit "still not working? email us" tap.
+ */
 export function buildWaitlistMailtoUrl(email: string): string {
   const subject = encodeURIComponent("OpenCode Connect Waitlist")
   const body = encodeURIComponent(email ? `Sign me up!\n\nEmail: ${email}` : "Sign me up!")
@@ -41,19 +46,19 @@ export function buildWaitlistMailtoUrl(email: string): string {
 export type WaitlistResult =
   /** Signup persisted server-side. */
   | { ok: true; email: string }
-  /** Signup not persisted. `fallback` decides the UX: true -> open the
-   *  mailto fallback so the signup still reaches the support inbox;
+  /** Signup not persisted. `retryable` decides the UX: true -> the same
+   *  request can succeed later, so queue it and retry on reconnect;
    *  false -> the input (or server validation) is wrong, ask the user to fix
-   *  their email instead of mailing garbage. */
-  | { ok: false; email: string; fallback: boolean; error: string }
+   *  their email instead of queueing garbage forever. */
+  | { ok: false; email: string; retryable: boolean; error: string }
 
 /**
- * Fallback decision, isolated for testability:
- * - transport failure (offline, DNS, timeout) -> mailto keeps the signup alive
- * - 5xx -> server broken through no fault of the user's -> mailto
- * - 4xx -> the server rejected this email; mailing it wouldn't help
+ * Retry decision, isolated for testability:
+ * - transport failure (offline, DNS, timeout) -> retry when connectivity returns
+ * - 5xx -> server broken through no fault of the user's -> retry
+ * - 4xx -> the server rejected this email; repeating it wouldn't help
  */
-export function shouldFallbackToMailto(outcome: { kind: "network-error" } | { kind: "http"; status: number }): boolean {
+export function isRetryableFailure(outcome: { kind: "network-error" } | { kind: "http"; status: number }): boolean {
   if (outcome.kind === "network-error") return true
   return outcome.status >= 500
 }
@@ -78,7 +83,7 @@ function serverError(body: unknown): string | undefined {
 export async function submitWaitlistSignup(rawEmail: string, deps: WaitlistDeps = {}): Promise<WaitlistResult> {
   const email = normalizeWaitlistEmail(rawEmail)
   if (email === null) {
-    return { ok: false, email: rawEmail.trim(), fallback: false, error: "Enter a valid email address." }
+    return { ok: false, email: rawEmail.trim(), retryable: false, error: "Enter a valid email address." }
   }
 
   const fetchFn = deps.fetchFn ?? (fetch as unknown as FetchLike)
@@ -99,7 +104,7 @@ export async function submitWaitlistSignup(rawEmail: string, deps: WaitlistDeps 
     return {
       ok: false,
       email,
-      fallback: shouldFallbackToMailto({ kind: "http", status: res.status }),
+      retryable: isRetryableFailure({ kind: "http", status: res.status }),
       error: message || `Signup failed (HTTP ${res.status}).`,
     }
   } catch (error: unknown) {
@@ -108,10 +113,227 @@ export async function submitWaitlistSignup(rawEmail: string, deps: WaitlistDeps 
     return {
       ok: false,
       email,
-      fallback: shouldFallbackToMailto({ kind: "network-error" }),
+      retryable: isRetryableFailure({ kind: "network-error" }),
       error: aborted ? `timeout after ${timeoutMs}ms` : err?.message || String(error),
     }
   } finally {
     clearTimeout(timer)
   }
+}
+
+// ---------------------------------------------------------------------------
+// Durable retry queue (AGE-87)
+// ---------------------------------------------------------------------------
+//
+// Before this, a signup that hit a network error / 8s timeout / 5xx was handed
+// straight to a `mailto:` composer. That is lossy by design: it depends on the
+// user actually pressing send in their mail client, and on us reconciling the
+// support inbox into Brevo list 4 forever (AGE-61's hourly reconciler). 20 of
+// 21 signups were lost that way before that reconciler existed.
+//
+// Instead we persist the pending signup on the device and retry it on the next
+// foreground / connectivity. `mailto:` survives only as a last-resort,
+// USER-INITIATED escape hatch once retries are clearly not working.
+//
+// Lives in this file (rather than its own module) so it stays a dependency-free
+// leaf that `node --test` can run directly, the same constraint that keeps
+// react-native imports out of here. Storage and the clock are injected; the
+// production AsyncStorage adapter is waitlist-queue-storage.ts.
+
+export const WAITLIST_QUEUE_KEY = "opencode.waitlist.pending.v1"
+
+/** Cap the queue so a broken device can't grow storage without bound. */
+export const WAITLIST_QUEUE_MAX = 5
+
+/** After this many failed attempts the UI offers the manual email escape hatch. */
+export const WAITLIST_QUEUE_ATTEMPTS_BEFORE_MANUAL = 3
+
+/** Entries older than this are dropped: the address is stale, the user moved on. */
+export const WAITLIST_QUEUE_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+export interface QueuedSignup {
+  /** Already normalized (trimmed/lowercased) by normalizeWaitlistEmail. */
+  email: string
+  /** Epoch ms of the first attempt. */
+  queuedAt: number
+  /** Number of failed submit attempts so far (>= 1 — enqueue follows a failure). */
+  attempts: number
+  /** Epoch ms of the last attempt. */
+  lastAttemptAt: number
+  /** Last transport/server error, for diagnostics only. */
+  lastError?: string
+}
+
+/**
+ * Minimal storage port. AsyncStorage satisfies this structurally, so does a
+ * plain Map in tests. Deliberately not typed against AsyncStorage so this file
+ * stays importable by `node --test`.
+ */
+export interface QueueStorage {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+}
+
+function isQueuedSignup(value: unknown): value is QueuedSignup {
+  if (typeof value !== "object" || value === null) return false
+  const entry = value as Record<string, unknown>
+  return (
+    typeof entry.email === "string" &&
+    normalizeWaitlistEmail(entry.email) === entry.email &&
+    typeof entry.queuedAt === "number" &&
+    Number.isFinite(entry.queuedAt) &&
+    typeof entry.attempts === "number" &&
+    Number.isFinite(entry.attempts)
+  )
+}
+
+/** Reads the queue, tolerating absent/corrupt/foreign JSON (never throws). */
+export async function loadQueue(storage: QueueStorage): Promise<QueuedSignup[]> {
+  let raw: string | null = null
+  try {
+    raw = await storage.getItem(WAITLIST_QUEUE_KEY)
+  } catch {
+    return []
+  }
+  if (!raw) return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(isQueuedSignup).map((entry) => ({
+      ...entry,
+      lastAttemptAt: typeof entry.lastAttemptAt === "number" ? entry.lastAttemptAt : entry.queuedAt,
+    }))
+  } catch {
+    return []
+  }
+}
+
+async function saveQueue(storage: QueueStorage, queue: QueuedSignup[]): Promise<void> {
+  try {
+    if (queue.length === 0) await storage.removeItem(WAITLIST_QUEUE_KEY)
+    else await storage.setItem(WAITLIST_QUEUE_KEY, JSON.stringify(queue))
+  } catch {
+    // Storage unavailable: the retry is lost, but the caller already told the
+    // user the truth ("saved, we'll finish signing you up") only when this
+    // resolves. enqueueSignup() surfaces the failure via its return value.
+    throw new Error("waitlist queue storage unavailable")
+  }
+}
+
+/** Drops entries past the TTL. Exported for the test that pins the policy. */
+export function pruneQueue(queue: QueuedSignup[], now: number): QueuedSignup[] {
+  return queue.filter((entry) => now - entry.queuedAt < WAITLIST_QUEUE_TTL_MS)
+}
+
+/**
+ * Persists a failed signup for later retry. Dedupes by email (an impatient
+ * user tapping twice must not produce two entries) and keeps the newest
+ * WAITLIST_QUEUE_MAX entries.
+ *
+ * Returns the stored entry, or null when the email is invalid or storage
+ * refused the write — in that case the caller must NOT tell the user we saved it.
+ */
+export async function enqueueSignup(
+  storage: QueueStorage,
+  rawEmail: string,
+  options: { now?: number; error?: string } = {},
+): Promise<QueuedSignup | null> {
+  const email = normalizeWaitlistEmail(rawEmail)
+  if (email === null) return null
+  const now = options.now ?? Date.now()
+
+  const existing = pruneQueue(await loadQueue(storage), now)
+  const previous = existing.find((entry) => entry.email === email)
+  const entry: QueuedSignup = {
+    email,
+    queuedAt: previous?.queuedAt ?? now,
+    attempts: (previous?.attempts ?? 0) + 1,
+    lastAttemptAt: now,
+    ...(options.error ? { lastError: options.error } : {}),
+  }
+  const next = [...existing.filter((e) => e.email !== email), entry].slice(-WAITLIST_QUEUE_MAX)
+  try {
+    await saveQueue(storage, next)
+  } catch {
+    return null
+  }
+  return entry
+}
+
+export async function removeFromQueue(storage: QueueStorage, email: string): Promise<void> {
+  const queue = await loadQueue(storage)
+  const next = queue.filter((entry) => entry.email !== email)
+  if (next.length === queue.length) return
+  try {
+    await saveQueue(storage, next)
+  } catch {
+    // best effort
+  }
+}
+
+export interface FlushOutcome {
+  /** Entries that reached the server (Brevo list 4). */
+  synced: string[]
+  /** Entries the server permanently rejected (4xx) — dropped, retrying can't help. */
+  rejected: string[]
+  /** Entries still pending after this flush. */
+  pending: QueuedSignup[]
+}
+
+export type SubmitFn = (email: string) => Promise<WaitlistResult>
+
+/**
+ * Retries every pending signup once. Called on app foreground and when the
+ * waitlist screen mounts.
+ *
+ * - ok            -> drop (it's in Brevo now)
+ * - 4xx           -> drop (the server will never accept this address)
+ * - network/5xx   -> keep, bump attempts (retry next foreground)
+ *
+ * Never throws: a flush is a background best-effort action.
+ */
+export async function flushQueue(
+  storage: QueueStorage,
+  options: { submit?: SubmitFn; now?: number } = {},
+): Promise<FlushOutcome> {
+  const now = options.now ?? Date.now()
+  const submit = options.submit ?? ((email: string) => submitWaitlistSignup(email))
+
+  const queue = pruneQueue(await loadQueue(storage), now)
+  const synced: string[] = []
+  const rejected: string[] = []
+  const pending: QueuedSignup[] = []
+
+  for (const entry of queue) {
+    let result: WaitlistResult
+    try {
+      result = await submit(entry.email)
+    } catch (error: unknown) {
+      pending.push({ ...entry, attempts: entry.attempts + 1, lastAttemptAt: now, lastError: String(error) })
+      continue
+    }
+    if (result.ok) {
+      synced.push(entry.email)
+    } else if (!result.retryable) {
+      rejected.push(entry.email)
+    } else {
+      pending.push({ ...entry, attempts: entry.attempts + 1, lastAttemptAt: now, lastError: result.error })
+    }
+  }
+
+  try {
+    await saveQueue(storage, pending)
+  } catch {
+    // Storage went away mid-flush; the in-memory outcome is still accurate.
+  }
+  return { synced, rejected, pending }
+}
+
+/**
+ * True once an entry has failed enough times that we should stop implying
+ * "we'll handle it" and offer the manual email escape hatch instead.
+ */
+export function needsManualEscapeHatch(entry: QueuedSignup | null | undefined): boolean {
+  return !!entry && entry.attempts >= WAITLIST_QUEUE_ATTEMPTS_BEFORE_MANUAL
 }


### PR DESCRIPTION
Closes the last in-app source of lost OpenCode Connect waitlist signups (AGE-87, follow-up to AGE-61).

## The defect

`shouldFallbackToMailto` handed a **current-build** user a `mailto:` composer on any network error, 8s timeout or 5xx. That is lossy by design — it depends on the user pressing send in their mail client, and on us reconciling `support@agentlabs.cc` into Brevo list 4 forever. 20 of 21 signups were lost that way before AGE-61's hourly reconciler existed, and Play's active base is ~100% on v0.4.10+, so this was not just the ~436 stale sideloads.

## What changed

| Before | After |
| --- | --- |
| network error / timeout / 5xx → open `mailto:` immediately | persist to `opencode.waitlist.pending.v1` (AsyncStorage), retry on every app foreground + on Add Connection mount |
| user sees nothing but a mail composer | user sees "Saved on this device — we'll finish signing you up as soon as you're back online" |
| `mailto:` is the silent default | `mailto:` is a user-initiated tap ("Still not working? Email us instead"), shown after 3 failed attempts or when device storage itself refuses the write |
| 4xx → alert | unchanged (non-retryable: the server will never accept that address) |

Queue policy: dedupe by email, cap 5, 30-day TTL, corrupt/foreign JSON discarded rather than replayed, storage failure never reported to the user as success.

`WaitlistResult.fallback` → `retryable` and `shouldFallbackToMailto` → `isRetryableFailure`: the decision is about retry, not about mail.

## Tests

16 new cases in `src/lib/waitlist-queue.test.ts` (storage + clock injected, plain `node --test`), including the acceptance case from the issue:

> `offline signup reaches the server on the next flush, with no mail client involved` — tap while offline → queued → still offline (attempts bumped, entry kept) → reconnect → submitted, queue emptied, no `mailto:` URL ever built.

`npm test` → 237 pass / 0 fail. `npm run typecheck` clean.

## Also in this PR

`distribution/waitlist-signup-path-coverage.md` and `scripts/play-version-share.mjs` (the AGE-61 Play-version measurement) existed only as uncommitted local files; committed here, with the doc's "current builds still leak" section rewritten to match this fix.

## Expected effect

The hourly reconciler's `synced_count` should trend to the sideload-only cohort (~436 pre-v0.4.8 installs, unfixable by shipping code). It stays as the safety net.