### PR TITLE
docs(waitlist): record v0.4.13 = Play versionCode 149 (production)

### DIFF
--- a/distribution/waitlist-signup-path-coverage.md
+++ b/distribution/waitlist-signup-path-coverage.md
@@ -40,7 +40,7 @@ returns 0 results) and the app is not on IzzyOnDroid, so those channels contribu
 
 ## After-number: how it gets attributed (AGE-100)
 
-_Pending — v0.4.13 (the first build users can actually run the retry queue on) ships 2026-08-14._
+_Pending — v0.4.13 (the first build users can actually run the retry queue on) went to the Play **production** track on 2026-08-14 as **versionCode 149** ([run 31786473735](https://github.com/dzianisv/opencode-mobile/actions/runs/31786473735)). Re-read one week out._
 
 Baseline at release time, from the hourly reconciler's last run before the cut
 (`Waitlist Mailto Reconcile`, 2026-08-14 07:59 UTC): `scanned=34 synced=0 skipped=34 failed=0`

--- a/scripts/play-version-share.mjs
+++ b/scripts/play-version-share.mjs
@@ -86,6 +86,8 @@ const VERSION_NAMES = {
   142: "0.4.10",
   143: "0.4.11",
   146: "0.4.12",
+  // v0.4.13 (retry queue + mailto version stamp) — production dispatch run 49.
+  149: "0.4.13",
 };
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
v0.4.13 shipped to the Play **production** track as versionCode 149 (workflow run 31786473735, edit committed).

- `scripts/play-version-share.mjs`: add `149 -> 0.4.13` so the version-share report can name the new build instead of reporting an unknown versionCode.
- `distribution/waitlist-signup-path-coverage.md`: record the release date, track and versionCode next to the pending after-number.

Ref: AGE-100
