### PR TITLE
fix(release): give v0.4.15 its own versionCode so the release can actually ship

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,8 +94,8 @@ android {
         applicationId 'cc.agentlabs.opencode'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 41
-        versionName "0.4.14"
+        versionCode 42
+        versionName "0.4.15"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/app.json
+++ b/app.json
@@ -35,7 +35,7 @@
     },
     "android": {
       "package": "cc.agentlabs.opencode",
-      "versionCode": 41,
+      "versionCode": 42,
       "usesCleartextTraffic": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",

--- a/distribution/changelogs/42.txt
+++ b/distribution/changelogs/42.txt
@@ -1,0 +1,5 @@
+v0.4.15 — The app now tells you when a new version is out
+
+• Installs from a downloaded APK, F-Droid or a mirror had no way to learn a newer version existed. The app now checks once a day and shows a dismissible banner when one is available.
+• "Not now" is remembered for that version only.
+• Settings now shows the version you are actually running instead of a hard-coded placeholder.

--- a/fastlane/metadata/android/en-US/changelogs/42.txt
+++ b/fastlane/metadata/android/en-US/changelogs/42.txt
@@ -1,0 +1,5 @@
+v0.4.15 — The app now tells you when a new version is out
+
+• Installs from a downloaded APK, F-Droid or a mirror had no way to learn a newer version existed. The app now checks once a day and shows a dismissible banner when one is available.
+• "Not now" is remembered for that version only.
+• Settings now shows the version you are actually running instead of a hard-coded placeholder.

--- a/scripts/check-version-parity.mjs
+++ b/scripts/check-version-parity.mjs
@@ -23,6 +23,37 @@ if (code !== expectedCode) {
   errors.push(`Gradle versionCode ${Number.isNaN(code) ? "missing" : code} != app.json versionCode ${expectedCode}`);
 }
 
+// A versionCode left at the previous release's value is the silent half of this
+// failure: version metadata is internally consistent, Play still accepts the
+// upload (CI overrides the code with run_number+100), but the F-Droid repo and
+// every direct-APK install key upgrades off versionCode — so a 0.4.15 APK
+// carrying 0.4.14's code is never offered to the cohort it was cut for.
+// The changelog file is named after the versionCode and its first line names
+// the version, so requiring the two to agree pins the code to this release.
+const changelogPath = `distribution/changelogs/${expectedCode}.txt`;
+let changelog = null;
+try {
+  changelog = await readFile(changelogPath, "utf8");
+} catch {
+  errors.push(`${changelogPath} is missing — every release needs a changelog named after its versionCode`);
+}
+
+if (changelog !== null) {
+  const firstLine = changelog.split("\n", 1)[0].trim();
+  if (!firstLine.startsWith(`v${expectedName}`)) {
+    errors.push(
+      `${changelogPath} describes "${firstLine}", not v${expectedName} — versionCode ${expectedCode} belongs to an earlier release, so bump it`,
+    );
+  }
+}
+
+const fastlanePath = `fastlane/metadata/android/en-US/changelogs/${expectedCode}.txt`;
+try {
+  await readFile(fastlanePath, "utf8");
+} catch {
+  errors.push(`${fastlanePath} is missing — F-Droid reads its release notes from here`);
+}
+
 if (errors.length) {
   console.error(errors.join("\n"));
   process.exitCode = 1;


### PR DESCRIPTION
## Why

Cutting v0.4.15 (f564869) bumped `package.json` + `app.json` `expo.version` but not `android/app/build.gradle` (still `versionCode 41` / `versionName "0.4.14"`) or `app.json` `android.versionCode` (still 41). On tag `v0.4.15`:

- **F-Droid publish [31820921979](https://github.com/dzianisv/opencode-mobile/actions/runs/31820921979) failed** at `npm run check:versions`, so nothing reached `fdroid/repo`.
- **No GitHub release exists for v0.4.15** — `build.yml`'s `release` job needs `build` + `build-fdroid`, and the same parity check fails the `test` job. The in-app update check added in #179 polls **GitHub releases/latest**, so the mechanism this release exists to ship had nothing to find.
- **versionCode 41 is v0.4.14's.** F-Droid and direct-APK installs key upgrades off versionCode, so even a green publish would not have been offered to the stale cohort. Play was unaffected only because the publish workflow overrides the code with `run_number + 100` (its production upload of `0.4.15` is fine).

## What changed

- `versionCode 42` / `versionName "0.4.15"` in `android/app/build.gradle`, `android.versionCode 42` in `app.json`.
- `distribution/changelogs/42.txt` + `fastlane/metadata/android/en-US/changelogs/42.txt` (F-Droid reads the fastlane copy).
- `scripts/check-version-parity.mjs` now also requires `distribution/changelogs/<versionCode>.txt` to exist **and to describe the version being released**, plus the fastlane copy. A stale versionCode is otherwise internally consistent and silent — the existing checks all passed on it.

## Verification

- `npm run check:versions` → `Version metadata aligned: 0.4.15 (42)`; with the code put back to 41 it fails with `distribution/changelogs/41.txt describes "v0.4.14 …", not v0.4.15 — versionCode 41 belongs to an earlier release, so bump it`. It discriminates.
- `npm test` → 320 pass.

After merge the `v0.4.15` tag is moved to this commit so the F-Droid publish and the GitHub release actually run for it. AGE-111.