### PR TITLE
fix(events): reconcile open session transcript after SSE reconnect

### DIFF
--- a/src/stores/events.ts
+++ b/src/stores/events.ts
@@ -145,6 +145,37 @@ async function resyncBusySessions() {
   )
 }
 
+// Reconcile the transcript of the session the user currently has open, after
+// an SSE reconnect.
+//
+// resyncBusySessions() above is not enough on its own. It only considers
+// sessions this client has marked "busy", and a client only learns a session
+// is busy *from an SSE event*. If the stream was down while another client
+// (CLI, TUI, another device) submitted a prompt, this client never saw the
+// busy `session.status` event, so the session is still "idle" in its store,
+// resyncBusySessions() finds nothing to do, and — because reconnect resumes
+// the stream from "now" and does not replay missed events — the messages that
+// arrived during the gap are never fetched. The open transcript then stays
+// stale until the user navigates away and back, which is the reported
+// cross-client staleness symptom.
+//
+// refreshMessages() re-fetches the current session and replaces messages/parts
+// without touching isLoading, so this lands as a silent background reconcile
+// rather than a spinner over content the user is already reading.
+//
+// Note this can overlap with resyncBusySessions() for a session that was busy
+// and has since gone idle — both would refresh. That costs one redundant GET
+// on an infrequent event, which is cheaper than the coupling needed to dedupe.
+async function reconcileOpenSession() {
+  const sessions = useSessions.getState()
+  if (!sessions.currentSession) return
+  try {
+    await sessions.refreshMessages()
+  } catch (err) {
+    console.warn("[Events] Failed to reconcile open session after reconnect:", err)
+  }
+}
+
 export const useEvents = create<EventsState>((set, get) => ({
   connected: false,
   authError: false,
@@ -232,6 +263,10 @@ export const useEvents = create<EventsState>((set, get) => ({
           if (isReconnect && !resyncedAfterReconnect) {
             resyncedAfterReconnect = true
             void resyncBusySessions()
+            // Backfill content missed while the stream was down. Separate from
+            // resyncBusySessions(), which only repairs *status* and only for
+            // sessions already known to be busy — see reconcileOpenSession().
+            void reconcileOpenSession()
           }
 
           const payload = (event as any).payload || event


### PR DESCRIPTION
A prompt submitted from another client (CLI, TUI, a second device) while this client's SSE stream was down never appears in an already-open session until the user navigates away and back.

## Root cause

`resyncBusySessions()` is the only reconnect-time reconciliation, and it returns immediately when no session is marked busy:

```js
const busySessionIDs = Object.entries(useEvents.getState().sessionStatus)
  .filter(([, status]) => status.type === "busy")
  .map(([sessionID]) => sessionID)
if (busySessionIDs.length === 0) return
```

But a client only learns a session is busy **from an SSE `session.status` event**. If the stream was down when the other client submitted the prompt, this client never saw that event — so the session is still `idle` in its store, `resyncBusySessions()` finds nothing to do, and since reconnect resumes the stream from "now" without replaying missed events (as the comment above that function already notes), the messages from the gap are never fetched by anything.

The session screen does subscribe to `reconnectAttempts`, but only to render the reconnect banner. Nothing refetches on reconnect.

## The change

`reconcileOpenSession()`, invoked alongside `resyncBusySessions()` in the same once-per-reconnect block: refetch the currently-open session's transcript unconditionally.

`refreshMessages()` replaces messages/parts without touching `isLoading`, so this lands as a silent background reconcile rather than a spinner over content the user is already reading — which only holds because #151 stopped same-session refreshes from forcing the loading state. The two changes are complementary:

- **#151** fixed a spinner *hiding* content that was arriving.
- **This** fixes content that never arrives at all.

Same user-visible symptom, different layer.

It can overlap with `resyncBusySessions()` for a session that was busy and has since gone idle — both would refresh. That costs one redundant GET on an infrequent event, which seemed cheaper than the coupling needed to dedupe; happy to change that if you'd prefer.

## Verification

Reproduced and verified on an Android 12 emulator against a live server:

| Step | Result |
|---|---|
| Post a message while connected | Appears live — baseline SSE delivery works |
| Enable airplane mode | Banner shows "Reconnecting… (attempt 5)" |
| Post from another client while offline | **Not** shown on device — reproduces the bug's precondition |
| Restore network, wait, **do not navigate** | Message **backfills automatically**; banner clears; no spinner |

The last step is the regression check: before this change the transcript stayed stale until the user left the session and re-entered. `noReply: true` was used throughout so the test exercises prompt acceptance, persistence and realtime delivery without model timing.

`tsc --noEmit` clean; full suite passes (286 tests) on this branch.