### PR TITLE
fix(android): account for edge-to-edge inset in keyboard avoidance

### DIFF
--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -39,6 +39,7 @@ import { useConnections } from "../../src/stores/connections"
 import { useAuth } from "../../src/stores/auth"
 import { useCatalog } from "../../src/stores/catalog"
 import { useSpeech } from "../../src/lib/speech"
+import { keyboardVerticalOffset } from "../../src/lib/keyboard-offset"
 
 // --- Builtin slash commands ---
 const BUILTIN_COMMANDS: SlashCommand[] = [
@@ -605,8 +606,16 @@ export default function SessionScreen() {
         // bottom toolbar + input were left completely hidden behind the
         // keyboard (#147). "padding" restores avoidance without depending
         // on native resize.
+        //
+        // "padding" alone is still not enough on Android, though (#156):
+        // KeyboardAvoidingView measures its own frame in *window* coordinates
+        // but reads the keyboard's screenY in *screen* coordinates, and under
+        // edge-to-edge those origins differ by the status-bar inset — so the
+        // padding lands short by exactly that much and the composer stays
+        // hidden. keyboardVerticalOffset closes the gap; see
+        // src/lib/keyboard-offset.ts for the measured numbers.
         behavior="padding"
-        keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
+        keyboardVerticalOffset={keyboardVerticalOffset(Platform.OS, insets.top)}
       >
         {/* Session info pulldown */}
         <SessionInfo

--- a/src/lib/keyboard-offset.test.ts
+++ b/src/lib/keyboard-offset.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { IOS_KEYBOARD_VERTICAL_OFFSET, keyboardVerticalOffset } from "./keyboard-offset.ts"
+
+test("iOS keeps its existing empirical offset regardless of inset", () => {
+  assert.equal(keyboardVerticalOffset("ios", 0), IOS_KEYBOARD_VERTICAL_OFFSET)
+  assert.equal(keyboardVerticalOffset("ios", 48.857), IOS_KEYBOARD_VERTICAL_OFFSET)
+})
+
+test("Android offsets by the status-bar inset to reconcile window vs screen coords", () => {
+  // Measured on an Android 12 emulator: this exact value closes the 48.857dp
+  // shortfall that left the composer behind the keyboard.
+  assert.equal(keyboardVerticalOffset("android", 48.857), 48.857)
+})
+
+test("Android with no status-bar inset needs no correction", () => {
+  assert.equal(keyboardVerticalOffset("android", 0), 0)
+})
+
+test("a negative/bogus inset never pushes content down", () => {
+  assert.equal(keyboardVerticalOffset("android", -20), 0)
+})
+
+// Regression guard for the arithmetic the offset exists to fix.
+test("offset makes computed padding equal the real keyboard height", () => {
+  const windowBottom = 748.857 // frame.y + frame.height, window coords
+  const keyboardScreenY = 511.714 // screen coords
+  const keyboardHeight = 286
+  const insetTop = 48.857
+
+  const withoutFix = windowBottom - keyboardScreenY
+  assert.ok(withoutFix < keyboardHeight, "precondition: unfixed padding is short")
+
+  const offset = keyboardVerticalOffset("android", insetTop)
+  const withFix = windowBottom - (keyboardScreenY - offset)
+  assert.ok(Math.abs(withFix - keyboardHeight) < 0.01, `expected ~${keyboardHeight}, got ${withFix}`)
+})

--- a/src/lib/keyboard-offset.ts
+++ b/src/lib/keyboard-offset.ts
@@ -1,0 +1,48 @@
+// KeyboardAvoidingView's `keyboardVerticalOffset`, per platform.
+//
+// Why Android needs a non-zero value under edge-to-edge:
+//
+// RN's KeyboardAvoidingView derives its padding from
+//
+//     keyboardY = keyboardFrame.screenY - keyboardVerticalOffset
+//     padding   = max(frame.y + frame.height - keyboardY, 0)
+//
+// `frame` comes from the view's own onLayout, which is in **window**
+// coordinates — the origin sits below the status bar. `keyboardFrame.screenY`
+// is in **screen** coordinates, measured from the true top of the display.
+// Before Expo's mandatory edge-to-edge those two origins coincided, because
+// the app window started below the status bar and the OS resized it
+// (adjustResize) when the keyboard opened. Under edge-to-edge the window spans
+// the full display, the two spaces no longer agree, and the computed padding
+// comes up short by exactly the status-bar inset.
+//
+// Measured on an Android 12 emulator (Pixel 3 XL profile, scale 3.5), keyboard
+// open on the session screen:
+//
+//     screen height        845.71 dp
+//     window height        748.86 dp
+//     insets.top            48.86 dp   insets.bottom 48 dp
+//     keyboard screenY     511.71 dp   height 286 dp
+//
+//     computed padding = 748.86 - 511.71 = 237.14 dp
+//     required padding =                   286.00 dp   (the real keyboard)
+//     shortfall        =                    48.86 dp   === insets.top
+//
+// 48.86 dp x 3.5 = 171 px, which is the composer row — hence "the input box is
+// invisible" (#156, and #53/#147 before it). Those earlier reports were each
+// answered with a different `behavior=` value; none addressed the coordinate
+// mismatch, which is why the bug kept coming back.
+//
+// Adding `insets.top` to keyboardVerticalOffset re-aligns the two spaces:
+// padding becomes 237.14 + 48.86 = 286, exactly the keyboard height.
+//
+// iOS keeps its existing empirical 90 — it does not have this mismatch, and
+// changing it is out of scope for this fix.
+
+export const IOS_KEYBOARD_VERTICAL_OFFSET = 90
+
+export function keyboardVerticalOffset(platform: string, insetTop: number): number {
+  if (platform === "ios") return IOS_KEYBOARD_VERTICAL_OFFSET
+  // Guard against a bogus/unmeasured inset so we never push content *down*.
+  return Math.max(0, insetTop)
+}


### PR DESCRIPTION
Closes #156

## Context

This is a focused extraction of the keyboard portion of blocked PR #182. It preserves the original fix and author credit from commit 38544db7, while leaving the unrelated SSE, auto-scroll, text-selection, and reconnect changes out of this PR.

## Root cause

Under Expo edge-to-edge Android, KeyboardAvoidingView measures its layout frame in window coordinates while the keyboard reports screen coordinates. The origins differ by the top status-bar inset, so the computed padding is short by exactly that inset and the composer remains behind the keyboard.

## Change

- Add a pure `keyboardVerticalOffset(platform, insetTop)` helper.
- Keep iOS's existing empirical offset of 90.
- Use the Android top safe-area inset as the offset, clamped to zero for invalid negative values.
- Apply the helper to the session screen's KeyboardAvoidingView.

## Verification

- Focused keyboard tests: 5 pass, 0 fail.
- Expanded repository tests: 325 pass, 0 fail.
- TypeScript typecheck: clean.
- Version parity check: 0.4.15 / Android versionCode 42 aligned.
- RED proof against upstream main: the new test fails with `ERR_MODULE_NOT_FOUND` because upstream main has no keyboard-offset implementation; the branch then passes all 5 focused tests.
- Diff contains exactly three files: `app/session/[id].tsx`, `src/lib/keyboard-offset.ts`, and `src/lib/keyboard-offset.test.ts`.

## Device verification

The reporter is using Android 17, but this Windows host currently has no Android SDK, emulator, ADB binary, or connected device. Therefore no Android 17 rendering claim is made here. The original commit documents on-device verification on a Pixel 3 XL / Android 12; please validate this focused PR on Android 17 hardware before merging.

## Related work

- Original bundled PR: #182
- Original keyboard issue: #156
