### PR TITLE
fix(android): prevent keyboard overlap across input screens

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
-    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
+    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustPan" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/app/connection/[id].tsx
+++ b/app/connection/[id].tsx
@@ -5,6 +5,8 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
+  KeyboardAvoidingView,
+  Platform,
   StyleSheet,
   useColorScheme,
   ActivityIndicator,
@@ -181,8 +183,13 @@ export default function EditConnectionScreen() {
   }
 
   return (
-    <ScrollView
+    <KeyboardAvoidingView
       style={[styles.container, isDark && styles.containerDark]}
+      enabled={Platform.OS === "ios"}
+      behavior="padding"
+    >
+    <ScrollView
+      style={{ flex: 1 }}
       contentContainerStyle={styles.content}
       keyboardShouldPersistTaps="handled"
     >
@@ -316,6 +323,7 @@ export default function EditConnectionScreen() {
         </TouchableOpacity>
       </View>
     </ScrollView>
+    </KeyboardAvoidingView>
   )
 }
 

--- a/app/connection/add.tsx
+++ b/app/connection/add.tsx
@@ -5,6 +5,8 @@ import {
   TextInput,
   TouchableOpacity,
   ScrollView,
+  KeyboardAvoidingView,
+  Platform,
   StyleSheet,
   useColorScheme,
   ActivityIndicator,
@@ -315,8 +317,13 @@ export default function AddConnectionScreen() {
   // Quick connect mode - simplified
   if (mode === "quick") {
     return (
-      <ScrollView
+      <KeyboardAvoidingView
         style={[styles.container, isDark && styles.containerDark]}
+        enabled={Platform.OS === "ios"}
+        behavior="padding"
+      >
+      <ScrollView
+        style={{ flex: 1 }}
         contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
@@ -516,13 +523,19 @@ export default function AddConnectionScreen() {
           <Ionicons name="chevron-forward" size={16} color={isDark ? "#888888" : "#666666"} />
         </TouchableOpacity>
       </ScrollView>
+      </KeyboardAvoidingView>
     )
   }
 
   // Advanced mode - full options
   return (
-    <ScrollView
+    <KeyboardAvoidingView
       style={[styles.container, isDark && styles.containerDark]}
+      enabled={Platform.OS === "ios"}
+      behavior="padding"
+    >
+    <ScrollView
+      style={{ flex: 1 }}
       contentContainerStyle={styles.content}
       keyboardShouldPersistTaps="handled"
     >
@@ -658,6 +671,7 @@ export default function AddConnectionScreen() {
         )}
       </TouchableOpacity>
     </ScrollView>
+    </KeyboardAvoidingView>
   )
 }
 

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -593,20 +593,9 @@ export default function SessionScreen() {
 
       <KeyboardAvoidingView
         style={[s.container, isDark && s.containerDark]}
-        // Both platforms use "padding" so the composer/toolbar is pushed up
-        // above the keyboard via JS-measured keyboard height.
-        //
-        // Android previously relied on the native android:windowSoftInputMode
-        // (adjustResize, see AndroidManifest.xml) with behavior={undefined}
-        // to let the OS resize the window (see #70/#53). Since adopting
-        // Expo's mandatory edge-to-edge display, Android no longer resizes
-        // the window when the keyboard opens — the system assumes insets are
-        // handled dynamically — so adjustResize became a no-op and the
-        // bottom toolbar + input were left completely hidden behind the
-        // keyboard (#147). "padding" restores avoidance without depending
-        // on native resize.
+        enabled={Platform.OS === "ios"}
         behavior="padding"
-        keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
+        keyboardVerticalOffset={90}
       >
         {/* Session info pulldown */}
         <SessionInfo


### PR DESCRIPTION
## Summary

- Let Android handle keyboard movement through `windowSoftInputMode="adjustPan"`.
- Keep `KeyboardAvoidingView` enabled only on iOS for the connection add/edit forms and session composer.
- Ensure the connection form scroll containers continue to fill the available screen.

## Scope

This covers the connection add/edit forms as well as the session composer. It is an alternative to the Android inset-based composer-only approach in #190 and the broader bundled changes in #182.

## Verification

- `npm test`: 333 passed, 0 failed.
- `npm run typecheck`: passed.
- Android release build: `assembleRelease -PreactNativeArchitectures=arm64-v8a` passed.

Related: #156, #190, #182.