### PR TITLE
fix(chat): label delegated task tool calls

### DIFF
--- a/src/components/chat/ToolCallCard.tsx
+++ b/src/components/chat/ToolCallCard.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react"
 import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator, ScrollView, Platform } from "react-native"
 import { Ionicons } from "@expo/vector-icons"
 import { useTranslation } from "react-i18next"
+import { taskToolTitle } from "../../lib/tool-title"
 import type { Part } from "../../lib/sdk"
 import { DiffView } from "./DiffView"
 
@@ -321,6 +322,7 @@ export function ToolCallCard({ tool, isDark }: Props) {
   const error = tool.state?.error?.message
   const elapsed = duration(tool.state?.time?.start, tool.state?.time?.end)
   const hasDetail = tool.state?.input !== undefined || tool.state?.output !== undefined || error
+  const title = tool.tool === "task" ? taskToolTitle(tool.state?.input) : undefined
 
   const toggle = useCallback(() => {
     if (hasDetail) setExpanded((v) => !v)
@@ -342,7 +344,7 @@ export function ToolCallCard({ tool, isDark }: Props) {
         <View style={s.headerLeft}>
           <Ionicons name={icon as any} size={16} color={color} />
           <Text style={[s.name, isDark && s.nameDark]} numberOfLines={1}>
-            {tool.state?.title || tool.tool || t("chat.toolCallCard.fallbackTitle")}
+            {title || tool.state?.title || tool.tool || t("chat.toolCallCard.fallbackTitle")}
           </Text>
           {elapsed && <Text style={[s.elapsed, isDark && s.elapsedDark]}>{elapsed}</Text>}
         </View>

--- a/src/lib/tool-title.test.ts
+++ b/src/lib/tool-title.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { taskToolTitle } from "./tool-title.ts"
+
+test("native Task input wins over a swarm-shaped fallback", () => {
+  assert.equal(
+    taskToolTitle({
+      subagent_type: "explore",
+      description: "Trace the session pipeline",
+      role: "Architect",
+      prompt: "Ignore this fallback",
+    }),
+    "Task explore: Trace the session pipeline",
+  )
+})
+
+test("swarm delegation uses its role and first non-empty prompt line", () => {
+  assert.equal(
+    taskToolTitle({ role: "Goomba - QA", prompt: "\n  Verify reconnect behavior   across clients\nIgnore later lines" }),
+    "Task Goomba - QA: Verify reconnect behavior across clients",
+  )
+})
+
+test("title is at most 60 visible characters including its ellipsis", () => {
+  const title = taskToolTitle({ role: "Architecture", prompt: "a".repeat(100) })!
+  assert.equal([...title].length, 60)
+  assert.equal(title.endsWith("…"), true)
+})
+
+test("unknown input leaves the card fallback intact", () => {
+  assert.equal(taskToolTitle({ prompt: "No role" }), undefined)
+  assert.equal(taskToolTitle(undefined), undefined)
+})

--- a/src/lib/tool-title.ts
+++ b/src/lib/tool-title.ts
@@ -1,0 +1,36 @@
+const TASK_TITLE_LENGTH = 60
+
+/**
+ * A compact title for native Task calls and OpencodeX swarm delegations.
+ * Native `{subagent_type, description}` input wins when both shapes exist.
+ */
+export function taskToolTitle(input: unknown) {
+  if (!input || typeof input !== "object") return undefined
+  const value = input as Record<string, unknown>
+  const agent = text(value.subagent_type)
+  const description = text(value.description)
+  if (agent || description) return truncate(`Task ${agent ?? "general"}: ${description ?? "subagent"}`)
+
+  const role = text(value.role)
+  if (!role) return undefined
+  const prompt = firstLine(value.prompt) ?? "delegation"
+  return truncate(`Task ${role}: ${prompt}`)
+}
+
+function text(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+function firstLine(value: unknown) {
+  return text(value)
+    ?.split("\n")
+    .find((line) => line.trim())
+    ?.trim()
+    .replace(/\s+/g, " ")
+}
+
+function truncate(value: string) {
+  const points = [...value]
+  if (points.length <= TASK_TITLE_LENGTH) return value
+  return `${points.slice(0, TASK_TITLE_LENGTH - 1).join("").trimEnd()}…`
+}


### PR DESCRIPTION
## Summary
- show descriptive titles for native Task and OpencodeX swarm delegation calls
- prefer native `{subagent_type, description}` input when both shapes are present
- cap labels at 60 visible characters including the ellipsis

## Validation
- TypeScript typecheck
- 4 focused unit tests
- QA review: PASS

Full Bun suite: 335 pass; 2 pre-existing Node mock tests cannot run under Bun (`context.mock.method` unsupported). No merge requested.