### PR TITLE
feat(identity): link repository and publisher on F-Droid and in Settings

### DIFF
--- a/.github/workflows/publish-fdroid.yml
+++ b/.github/workflows/publish-fdroid.yml
@@ -125,6 +125,13 @@ jobs:
           mkdir -p "$FDROID_DIR/repo"
           mkdir -p "$FDROID_DIR/metadata"
 
+          # Ship the committed app metadata (author/company, source-code link,
+          # license, description) into fdroidserver's metadata/ dir so `fdroid
+          # update` bakes it into the index. Without it, --create-metadata
+          # generates a minimal entry (name + version only, no author, no
+          # source link, license "Unknown") — see fdroid/metadata/cc.agentlabs.opencode.yml.
+          cp fdroid/metadata/cc.agentlabs.opencode.yml "$FDROID_DIR/metadata/"
+
           echo "${{ secrets.FDROID_REPO_KEYSTORE_B64 }}" | base64 -d > "$FDROID_DIR/repo-keystore.jks"
 
           cat > "$FDROID_DIR/config.yml" << CONFIGEOF

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -22,7 +22,7 @@ import {
 } from "../../src/lib/notifications"
 import type { Category } from "../../src/lib/notifications"
 import { hasTelemetryConsent, setTelemetryConsent } from "../../src/lib/telemetry"
-import { PRIVACY_POLICY_URL } from "../../src/lib/links"
+import { PRIVACY_POLICY_URL, REPOSITORY_URL, COMPANY_URL } from "../../src/lib/links"
 import { CURRENT_VERSION, checkForUpdate, type AvailableUpdate } from "../../src/lib/update-check"
 import type { LocalePreference } from "../../src/lib/i18n/locale-resolve"
 
@@ -289,7 +289,15 @@ export default function SettingsScreen() {
           label={t("settings.about.github.label")}
           description={t("settings.about.github.description")}
           isDark={isDark}
-          onPress={() => Linking.openURL("https://github.com/anomalyco/opencode")}
+          onPress={() => Linking.openURL(REPOSITORY_URL)}
+          right={<Ionicons name="open-outline" size={20} color={isDark ? "#666666" : "#999999"} />}
+        />
+        <SettingRow
+          icon="business"
+          label={t("settings.about.company.label")}
+          description={t("settings.about.company.description")}
+          isDark={isDark}
+          onPress={() => Linking.openURL(COMPANY_URL)}
           right={<Ionicons name="open-outline" size={20} color={isDark ? "#666666" : "#999999"} />}
         />
         <SettingRow

--- a/fdroid/metadata/cc.agentlabs.opencode.yml
+++ b/fdroid/metadata/cc.agentlabs.opencode.yml
@@ -1,0 +1,43 @@
+# F-Droid metadata for the self-hosted repository (fdroid/repo).
+#
+# This file is shipped into the repo index by .github/workflows/publish-fdroid.yml
+# (copied into fdroidserver's metadata/ dir before `fdroid update`). Without it,
+# fdroidserver's --create-metadata produces a minimal entry from the APK alone:
+# name + package id + version, with no author, no source-code link, no website,
+# and license "Unknown" — which is what the live index showed before this file
+# existed.
+#
+# Field values mirror distribution/fdroid-submission/metadata.yml (the F-Droid
+# mainline submission) so both listings identify the same author and repository.
+# Keep the two in sync.
+
+AntiFeatures:
+  NonFreeNet:
+    en-US: The app connects to a user-self-hosted opencode server which may in turn
+      connect to proprietary AI services (OpenAI API, Anthropic API, Google Gemini).
+      The app itself is fully open source and does not require any specific provider.
+Categories:
+  - Development
+License: MIT
+AuthorName: VIBE TECHNOLOGIES, LLC
+AuthorEmail: support@agentlabs.cc
+WebSite: https://agentlabs.cc/opencode
+SourceCode: https://github.com/dzianisv/opencode-mobile
+IssueTracker: https://github.com/dzianisv/opencode-mobile/issues
+Changelog: https://github.com/dzianisv/opencode-mobile/releases
+
+AutoName: OpenCode
+Summary: Android client for the opencode AI coding agent
+
+Description: |
+  Connect your Android phone to your own self-hosted opencode server and
+  steer your AI coding agent from anywhere: watch token-by-token streaming
+  output, review inline file diffs, and approve or reject tool calls.
+
+  All code, prompts, and AI responses travel directly between your phone
+  and your own opencode server — nothing passes through VIBE TECHNOLOGIES,
+  LLC's infrastructure. OpenCode Mobile is an independent, community-built
+  client and is not made by, endorsed by, or affiliated with the opencode
+  / Anomaly team.
+
+  MIT licensed. Source code: https://github.com/dzianisv/opencode-mobile

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -49,6 +49,10 @@
         "label": "GitHub",
         "description": "View source code"
       },
+      "company": {
+        "label": "Company",
+        "description": "VIBE TECHNOLOGIES, LLC — agentlabs.cc"
+      },
       "docs": {
         "label": "Documentation",
         "description": "Learn how to use OpenCode"

--- a/src/lib/i18n/zh-Hans.json
+++ b/src/lib/i18n/zh-Hans.json
@@ -49,6 +49,10 @@
         "label": "GitHub",
         "description": "查看源代码"
       },
+      "company": {
+        "label": "公司",
+        "description": "VIBE TECHNOLOGIES, LLC — agentlabs.cc"
+      },
       "docs": {
         "label": "文档",
         "description": "了解如何使用 OpenCode"

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -1,2 +1,6 @@
 export const PRIVACY_POLICY_URL = "https://dzianisv.github.io/opencode-mobile/privacy/"
 export const SETUP_GUIDE_URL = "https://dzianisv.github.io/opencode-mobile/guide/"
+// Source repository of OpenCode Mobile itself (NOT the upstream opencode agent).
+export const REPOSITORY_URL = "https://github.com/dzianisv/opencode-mobile"
+// Publisher behind OpenCode Mobile.
+export const COMPANY_URL = "https://agentlabs.cc/opencode"


### PR DESCRIPTION
## What / why

The F-Droid store listing and the in-app About screen did not point users to this app's repository or its publisher (VIBE TECHNOLOGIES, LLC).

### F-Droid self-hosted repo (`fdroid/repo`)
The live index (`index-v1.json`) is generated with `fdroid update --create-metadata`, which derives everything from the APK. Result: the app page shows no author, no source-code link, no website, and license **"Unknown"**.

- Adds `fdroid/metadata/cc.agentlabs.opencode.yml`, mirroring the mainline `distribution/fdroid-submission/metadata.yml`.
- `publish-fdroid.yml` copies it into fdroidserver's `metadata/` dir before `fdroid update`, so the published index now carries:
  - `authorName`: **VIBE TECHNOLOGIES, LLC**
  - `sourceCode`: github.com/dzianisv/opencode-mobile
  - `webSite`: agentlabs.cc/opencode · `issueTracker` · `changelog`
  - `license`: **MIT** (was "Unknown") · `summary` + full `description`

### In-app About (Settings)
- The "GitHub / View source code" row pointed to `github.com/anomalyco/opencode` (the **upstream** opencode repo). It now opens **this app's** repo (`dzianisv/opencode-mobile`).
- New "Company" row → `agentlabs.cc/opencode` (VIBE TECHNOLOGIES, LLC).
- i18n keys added to `en.json` + `zh-Hans.json` (catalog-parity test passes).

## Verification
- `npm run typecheck` ✅
- `npm test` — 333/333 ✅ (incl. i18n catalog-parity)
- Metadata YAML + JSON validated