### PR TITLE
fix(android): keep composer synchronized with IME

### DIFF
--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -39,6 +39,7 @@ import { useConnections } from "../../src/stores/connections"
 import { useAuth } from "../../src/stores/auth"
 import { useCatalog } from "../../src/stores/catalog"
 import { useSpeech } from "../../src/lib/speech"
+import { keyboardVerticalOffset } from "../../src/lib/keyboard-offset"
 
 // --- Builtin slash commands ---
 const BUILTIN_COMMANDS: SlashCommand[] = [
@@ -605,8 +606,13 @@ export default function SessionScreen() {
         // bottom toolbar + input were left completely hidden behind the
         // keyboard (#147). "padding" restores avoidance without depending
         // on native resize.
+        //
+        // The view frame is local to the route content below the native
+        // header, while keyboard screenY is global. Offset by the complete
+        // header (safe-area inset + the standard 56 dp Android header) to
+        // reconcile those coordinate spaces.
         behavior="padding"
-        keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
+        keyboardVerticalOffset={keyboardVerticalOffset(Platform.OS, insets.top)}
       >
         {/* Session info pulldown */}
         <SessionInfo

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   useColorScheme,
   KeyboardAvoidingView,
+  Keyboard,
   Platform,
   ActivityIndicator,
   Alert,
@@ -39,7 +40,7 @@ import { useConnections } from "../../src/stores/connections"
 import { useAuth } from "../../src/stores/auth"
 import { useCatalog } from "../../src/stores/catalog"
 import { useSpeech } from "../../src/lib/speech"
-import { keyboardVerticalOffset } from "../../src/lib/keyboard-offset"
+import { keyboardPadding, keyboardVerticalOffset } from "../../src/lib/keyboard-offset"
 
 // --- Builtin slash commands ---
 const BUILTIN_COMMANDS: SlashCommand[] = [
@@ -86,6 +87,20 @@ export default function SessionScreen() {
   const [input, setInput] = useState("")
   const [attachments, setAttachments] = useState<Attachment[]>([])
   const [showInfo, setShowInfo] = useState(false)
+  const [keyboardHeight, setKeyboardHeight] = useState(() => Keyboard.metrics()?.height ?? 0)
+
+  useEffect(() => {
+    if (Platform.OS !== "android") return
+    const show = Keyboard.addListener("keyboardDidShow", (event) => setKeyboardHeight(event.endCoordinates.height))
+    const hide = Keyboard.addListener("keyboardDidHide", () => setKeyboardHeight(0))
+    // Close the render-to-effect race: listeners are attached first, then the
+    // current native metrics become the source of truth.
+    setKeyboardHeight(Keyboard.metrics()?.height ?? 0)
+    return () => {
+      show.remove()
+      hide.remove()
+    }
+  }, [])
 
   const {
     currentSession,
@@ -593,25 +608,24 @@ export default function SessionScreen() {
       />
 
       <KeyboardAvoidingView
-        style={[s.container, isDark && s.containerDark]}
-        // Both platforms use "padding" so the composer/toolbar is pushed up
-        // above the keyboard via JS-measured keyboard height.
-        //
+        style={[
+          s.container,
+          isDark && s.containerDark,
+          Platform.OS === "android" && { paddingBottom: keyboardPadding(Platform.OS, keyboardHeight) },
+        ]}
         // Android previously relied on the native android:windowSoftInputMode
         // (adjustResize, see AndroidManifest.xml) with behavior={undefined}
         // to let the OS resize the window (see #70/#53). Since adopting
         // Expo's mandatory edge-to-edge display, Android no longer resizes
         // the window when the keyboard opens — the system assumes insets are
         // handled dynamically — so adjustResize became a no-op and the
-        // bottom toolbar + input were left completely hidden behind the
-        // keyboard (#147). "padding" restores avoidance without depending
-        // on native resize.
+        // bottom toolbar + input were left hidden behind the keyboard (#147).
         //
-        // The view frame is local to the route content below the native
-        // header, while keyboard screenY is global. Offset by the complete
-        // header (safe-area inset + the standard 56 dp Android header) to
-        // reconcile those coordinate spaces.
-        behavior="padding"
+        // RN 0.81 handles Android keyboardDidHide as another frame-change
+        // event, so a non-zero vertical offset survives as stale padding.
+        // Android therefore uses the IME's reported height directly in style;
+        // the hide listener above explicitly resets it to zero.
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={keyboardVerticalOffset(Platform.OS, insets.top)}
       >
         {/* Session info pulldown */}

--- a/src/lib/keyboard-offset.test.ts
+++ b/src/lib/keyboard-offset.test.ts
@@ -1,34 +1,34 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 import {
-  ANDROID_HEADER_CONTENT_HEIGHT,
   IOS_KEYBOARD_VERTICAL_OFFSET,
+  keyboardPadding,
   keyboardVerticalOffset,
 } from "./keyboard-offset.ts"
+
+test("Android uses the IME-reported height as bottom padding", () => {
+  assert.equal(keyboardPadding("android", 351.28), 351.28)
+})
+
+test("Android hide and invalid metrics produce zero padding", () => {
+  assert.equal(keyboardPadding("android", 0), 0)
+  assert.equal(keyboardPadding("android", -20), 0)
+})
+
+test("iOS does not receive Android's explicit keyboard padding", () => {
+  assert.equal(keyboardPadding("ios", 351.28), 0)
+})
 
 test("iOS keeps its existing empirical offset", () => {
   assert.equal(keyboardVerticalOffset("ios", 0), IOS_KEYBOARD_VERTICAL_OFFSET)
   assert.equal(keyboardVerticalOffset("ios", 61.29), IOS_KEYBOARD_VERTICAL_OFFSET)
 })
 
-test("Android offsets by the complete native header height", () => {
-  assert.equal(keyboardVerticalOffset("android", 61.293), 117.293)
+test("Android does not use KeyboardAvoidingView's vertical offset", () => {
+  assert.equal(keyboardVerticalOffset("android", 61.293), 0)
 })
 
-test("Android includes header content when the top inset is zero or invalid", () => {
-  assert.equal(keyboardVerticalOffset("android", 0), ANDROID_HEADER_CONTENT_HEIGHT)
-  assert.equal(keyboardVerticalOffset("android", -20), ANDROID_HEADER_CONTENT_HEIGHT)
-})
-
-// Pixel 11 Pro / Android 17 regression guard. With only the 61.29 dp safe-area
-// inset, the input overlapped the custom Trime IME by 106 px. Adding the
-// standard 56 dp header content makes the computed padding equal IME height.
-test("Android offset reconciles route-local and screen coordinates", () => {
-  const routeBottom = 741.65
-  const keyboardScreenY = 507.67
-  const keyboardHeight = 351.28
-  const offset = keyboardVerticalOffset("android", 61.29)
-  const padding = routeBottom - (keyboardScreenY - offset)
-
-  assert.ok(Math.abs(padding - keyboardHeight) < 0.01, `expected ~${keyboardHeight}, got ${padding}`)
+test("Pixel 11 Pro measurement maps directly to the required padding", () => {
+  const keyboardHeight = 1168 / (1280 / 393)
+  assert.equal(keyboardPadding("android", keyboardHeight), keyboardHeight)
 })

--- a/src/lib/keyboard-offset.test.ts
+++ b/src/lib/keyboard-offset.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import {
+  ANDROID_HEADER_CONTENT_HEIGHT,
+  IOS_KEYBOARD_VERTICAL_OFFSET,
+  keyboardVerticalOffset,
+} from "./keyboard-offset.ts"
+
+test("iOS keeps its existing empirical offset", () => {
+  assert.equal(keyboardVerticalOffset("ios", 0), IOS_KEYBOARD_VERTICAL_OFFSET)
+  assert.equal(keyboardVerticalOffset("ios", 61.29), IOS_KEYBOARD_VERTICAL_OFFSET)
+})
+
+test("Android offsets by the complete native header height", () => {
+  assert.equal(keyboardVerticalOffset("android", 61.293), 117.293)
+})
+
+test("Android includes header content when the top inset is zero or invalid", () => {
+  assert.equal(keyboardVerticalOffset("android", 0), ANDROID_HEADER_CONTENT_HEIGHT)
+  assert.equal(keyboardVerticalOffset("android", -20), ANDROID_HEADER_CONTENT_HEIGHT)
+})
+
+// Pixel 11 Pro / Android 17 regression guard. With only the 61.29 dp safe-area
+// inset, the input overlapped the custom Trime IME by 106 px. Adding the
+// standard 56 dp header content makes the computed padding equal IME height.
+test("Android offset reconciles route-local and screen coordinates", () => {
+  const routeBottom = 741.65
+  const keyboardScreenY = 507.67
+  const keyboardHeight = 351.28
+  const offset = keyboardVerticalOffset("android", 61.29)
+  const padding = routeBottom - (keyboardScreenY - offset)
+
+  assert.ok(Math.abs(padding - keyboardHeight) < 0.01, `expected ~${keyboardHeight}, got ${padding}`)
+})

--- a/src/lib/keyboard-offset.ts
+++ b/src/lib/keyboard-offset.ts
@@ -1,11 +1,15 @@
-// KeyboardAvoidingView computes its padding from a route-local view frame and
-// a global keyboard screenY. On Android this route begins below the native
-// stack header, so its vertical offset must include the complete header height.
+// iOS continues to use KeyboardAvoidingView's established offset. Android
+// applies the IME-reported height directly because RN 0.81's Android hide
+// event path can retain keyboardVerticalOffset as stale bottom padding.
 
 export const IOS_KEYBOARD_VERTICAL_OFFSET = 90
-export const ANDROID_HEADER_CONTENT_HEIGHT = 56
 
-export function keyboardVerticalOffset(platform: string, insetTop: number): number {
+export function keyboardPadding(platform: string, keyboardHeight: number): number {
+  if (platform !== "android") return 0
+  return Math.max(0, keyboardHeight)
+}
+
+export function keyboardVerticalOffset(platform: string, _insetTop: number): number {
   if (platform === "ios") return IOS_KEYBOARD_VERTICAL_OFFSET
-  return Math.max(0, insetTop) + ANDROID_HEADER_CONTENT_HEIGHT
+  return 0
 }

--- a/src/lib/keyboard-offset.ts
+++ b/src/lib/keyboard-offset.ts
@@ -1,0 +1,11 @@
+// KeyboardAvoidingView computes its padding from a route-local view frame and
+// a global keyboard screenY. On Android this route begins below the native
+// stack header, so its vertical offset must include the complete header height.
+
+export const IOS_KEYBOARD_VERTICAL_OFFSET = 90
+export const ANDROID_HEADER_CONTENT_HEIGHT = 56
+
+export function keyboardVerticalOffset(platform: string, insetTop: number): number {
+  if (platform === "ios") return IOS_KEYBOARD_VERTICAL_OFFSET
+  return Math.max(0, insetTop) + ANDROID_HEADER_CONTENT_HEIGHT
+}


### PR DESCRIPTION
Closes #194

## Root cause

On edge-to-edge Android, `adjustResize` no longer moves the composer above the IME. The `KeyboardAvoidingView` change proposed in #182 improves the layout, but a physical Pixel 11 Pro test still left the input partially covered.

A larger `keyboardVerticalOffset` can correct the open position, but React Native 0.81.5 handles Android `keyboardDidHide` as another frame-change event. With a non-zero offset, that leaves stale bottom padding after the IME closes, so the composer does not return to the bottom.

## Change

- Preserve the existing iOS `KeyboardAvoidingView` padding behavior and 90 dp offset.
- On Android, initialize from `Keyboard.metrics()`, subscribe to `keyboardDidShow` / `keyboardDidHide`, and apply the IME-reported height directly as bottom padding.
- Reset Android padding explicitly to zero on hide.
- Subscribe before resynchronizing native metrics so an IME transition during route mount cannot be lost.
- Add regression coverage for show, hide, invalid metrics, iOS isolation, and the measured Pixel geometry.

## Physical-device verification

Pixel 11 Pro, Android 17:

- Play v0.4.15 reproduced #194 with both Gboard and a custom Trime IME.
- The #182-style build moved the composer but still left 106 px of the input behind the IME.
- The first complete-header-offset build fixed opening but exposed stale padding after keyboard dismissal.
- The final APK was installed over the side-by-side test package and verified by the reporter: opening the IME keeps the full composer visible; dismissing it returns the composer to the bottom.

## Verification

- `npm test` — 339 passed
- `npm run typecheck`
- Keyboard offset tests — 6 passed
- Android arm64 release APK build
- Physical Pixel 11 Pro open/close cycle

The change is limited to the session keyboard integration and its small pure helper/tests.