### PR TITLE
fix(chat): keyboard cover input + blank card

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from "expo-status-bar"
 import { useColorScheme, View, ActivityIndicator, AppState } from "react-native"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
+import { KeyboardProvider } from "react-native-keyboard-controller"
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet"
 import { I18nextProvider, useTranslation } from "react-i18next"
 import i18n from "../src/lib/i18n/config"
@@ -171,6 +172,7 @@ function RootLayout() {
     <ErrorBoundary>
       <I18nextProvider i18n={i18n}>
       <GestureHandlerRootView style={{ flex: 1 }}>
+        <KeyboardProvider statusBarTranslucent navigationBarTranslucent>
         <BottomSheetModalProvider>
           <QueryClientProvider client={queryClient}>
             <AuthGate>
@@ -212,6 +214,7 @@ function RootLayout() {
             </AuthGate>
           </QueryClientProvider>
         </BottomSheetModalProvider>
+        </KeyboardProvider>
       </GestureHandlerRootView>
       {/* Telemetry consent modal — shown once on first launch */}
       <TelemetryConsentModal

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -7,11 +7,11 @@ import {
   TouchableOpacity,
   StyleSheet,
   useColorScheme,
-  KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
   Alert,
 } from "react-native"
+import { KeyboardStickyView } from "react-native-keyboard-controller"
 import { useLocalSearchParams, Stack, useRouter, useFocusEffect } from "expo-router"
 import { Ionicons } from "@expo/vector-icons"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -591,22 +591,8 @@ export default function SessionScreen() {
         }}
       />
 
-      <KeyboardAvoidingView
+      <View
         style={[s.container, isDark && s.containerDark]}
-        // Both platforms use "padding" so the composer/toolbar is pushed up
-        // above the keyboard via JS-measured keyboard height.
-        //
-        // Android previously relied on the native android:windowSoftInputMode
-        // (adjustResize, see AndroidManifest.xml) with behavior={undefined}
-        // to let the OS resize the window (see #70/#53). Since adopting
-        // Expo's mandatory edge-to-edge display, Android no longer resizes
-        // the window when the keyboard opens — the system assumes insets are
-        // handled dynamically — so adjustResize became a no-op and the
-        // bottom toolbar + input were left completely hidden behind the
-        // keyboard (#147). "padding" restores avoidance without depending
-        // on native resize.
-        behavior="padding"
-        keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
       >
         {/* Session info pulldown */}
         <SessionInfo
@@ -740,6 +726,10 @@ export default function SessionScreen() {
           <SlashPopover query={slashQuery} commands={allCommands} isDark={isDark} onSelect={handleSlashSelect} />
         )}
 
+        {/* Composer sticks above the keyboard (edge-to-edge safe).
+            offset = closed-keyboard inset so the bar rests on the
+            gesture nav pill instead of overlapping it. */}
+        <KeyboardStickyView offset={{ closed: -insets.bottom, opened: 0 }}>
         {/* Agent/model toolbar */}
         <View style={[s.toolbar, isDark && s.toolbarDark]}>
           <TouchableOpacity
@@ -838,7 +828,8 @@ export default function SessionScreen() {
             )}
           </View>
         </View>
-      </KeyboardAvoidingView>
+        </KeyboardStickyView>
+      </View>
 
       {/* Model picker bottom sheet */}
       <ModelPicker

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opencode-ai/mobile",
-  "version": "0.4.11",
+  "version": "0.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opencode-ai/mobile",
-      "version": "0.4.11",
+      "version": "0.4.15",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "5.2.8",
@@ -35,6 +35,7 @@
         "react-i18next": "^17.0.10",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-keyboard-controller": "^1.22.4",
         "react-native-marked": "8.0.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -8513,6 +8514,20 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-keyboard-controller": {
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.22.4.tgz",
+      "integrity": "sha512-2by3oJBQqKH9UAydlBeiEpivxIyTbt345bmverLym7vbEp4NXckWQLF0STnVuXYccRak5/sd3wMYDJPhv/9+3g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
       }
     },
     "node_modules/react-native-marked": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-i18next": "^17.0.10",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-keyboard-controller": "^1.22.4",
     "react-native-marked": "8.0.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react"
-import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from "react-native"
+import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, Dimensions, ActivityIndicator } from "react-native"
 import { Ionicons } from "@expo/vector-icons"
 import { Markdown } from "../markdown"
 import { ToolCallCard } from "./ToolCallCard"
@@ -96,6 +96,14 @@ export const MessageBubble = memo(
             </View>
           ))}
 
+        {/* Typing placeholder — assistant message arrived before any part */}
+        {!isUser && text.length === 0 && reasoning.length === 0 && toolParts.length === 0 && fileParts.length === 0 && (
+          <View style={s.typingRow}>
+            <ActivityIndicator size="small" color="#8b5cf6" />
+            <Text style={[s.typingText, isDark && s.typingTextDark]}>Typing…</Text>
+          </View>
+        )}
+
         {/* Tool calls */}
         {toolParts.map((tool) => (
           <ToolCallCard key={tool.id} tool={tool} isDark={isDark} />
@@ -170,4 +178,8 @@ const s = StyleSheet.create({
   },
   imageLabel: { fontSize: 10, color: "#666666", marginTop: 2, maxWidth: 200 },
   imageLabelDark: { color: "#888888" },
+
+  typingRow: { flexDirection: "row", alignItems: "center", gap: 8, paddingVertical: 4 },
+  typingText: { fontSize: 14, color: "#8b5cf6", fontStyle: "italic" },
+  typingTextDark: { color: "#a78bfa" },
 })


### PR DESCRIPTION
## Ringkasan
- Composer nempel di atas keyboard (gesture-nav Android) via KeyboardStickyView + KeyboardProvider (react-native-keyboard-controller). Menggantikan KeyboardAvoidingView yang mati di Expo edge-to-edge (#147, relevan #194, #156).
- Card assistant kosong diganti Typing... spinner sampe part pertama masuk (message.updated datang sebelum part.updated).

## Test
- [x] tsc --noEmit lolos lokal
- [x] lockfile sync (package-lock.json)
- [ ] CI upstream (secrets Sentry tersedia di sini)
- [ ] Tes device gesture-nav